### PR TITLE
Replace svn info for revision detection by git log+perl.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,13 +40,18 @@
     -->
     <target name="create-revision">
         <property name="revision.dir" value="${build.dir}"/>
-        <exec append="false" output="REVISION.XML" executable="svn" failifexecutionfails="false">
-            <env key="LANG" value="C"/>
-            <arg value="info"/>
-            <arg value="--xml"/>
-            <arg value="http://josm.openstreetmap.de/svn/trunk"/>
+        <exec append="false" output="REVISION.TMP" executable="git" failifexecutionfails="false">
+            <arg value="log"/>
+            <arg value="-1"/>
+            <arg value="--grep=git-svn-id"/>
+            <arg value="--pretty=format:%ai%n%B"/>
+            <arg value="HEAD"/>
+        </exec>
+        <exec append="false" input="REVISION.TMP" output="REVISION.XML" executable="perl" failifexecutionfails="false" error="REVISION.ERR">
+            <arg value="tools/commit2xml.pl"/>
         </exec>
         <xmlproperty file="REVISION.XML" prefix="version" keepRoot="false" collapseAttributes="true"/>
+        <delete file="REVISION.TMP"/>
         <delete file="REVISION.XML"/>
         <tstamp>
             <format property="build.tstamp" pattern="yyyy-MM-dd HH:mm:ss"/>
@@ -70,14 +75,19 @@ Build-Date: ${build.tstamp}
         </schemavalidate>
     </target>
     <target name="dist" depends="compile,create-revision,check-schemas">
-        <exec append="false" output="REVISION" executable="svn" failifexecutionfails="false">
-            <env key="LANG" value="C"/>
-            <arg value="info"/>
-            <arg value="--xml"/>
-            <arg value="http://josm.openstreetmap.de/svn/trunk"/>
+        <exec append="false" output="REVISION.TMP" executable="git" failifexecutionfails="false">
+            <arg value="log"/>
+            <arg value="-1"/>
+            <arg value="--grep=git-svn-id"/>
+            <arg value="--pretty=format:%ai%n%B"/>
+            <arg value="HEAD"/>
         </exec>
-        <xmlproperty file="REVISION" prefix="version" keepRoot="false" collapseAttributes="true"/>
-        <delete file="REVISION"/>
+        <exec append="false" input="REVISION.TMP" output="REVISION.XML" executable="perl" failifexecutionfails="false" error="REVISION.ERR">
+            <arg value="tools/commit2xml.pl"/>
+        </exec>
+        <xmlproperty file="REVISION.XML" prefix="version" keepRoot="false" collapseAttributes="true"/>
+        <delete file="REVISION.TMP"/>
+        <delete file="REVISION.XML"/>
         <property name="version.entry.commit.revision" value="UNKNOWN"/>
         <property name="version.entry.commit.date" value="UNKNOWN"/>
         <echo>Revision ${version.entry.commit.revision}</echo>

--- a/tools/commit2xml.pl
+++ b/tools/commit2xml.pl
@@ -1,0 +1,13 @@
+#!perl -w
+
+$l=<>;
+if ($l =~ /([-+: .\w]+)/) {
+    $date=$1;
+}
+
+while (<>) {
+    if (/git-svn-id: [^@]*@([0-9]+)\s/) {
+        $rev=$1;
+    }
+}
+print "<info><entry><commit". ($rev?" revision=\"$rev\"":"") .">". ($date?"<date>$date</date>":"") ."</commit></entry></info>\n";


### PR DESCRIPTION
I didn't like that revision detection (hacked long ago in bcbc70ea2e5c51b5d27222fe69c7e963645ca263) was trying to access josm.openstreetmap.de (it made building impossible when offline) and revision number was not always correct (when working with older revisions).

I replaced _svn info_ by _git log_ + _perl_.
_git log_ looks at the most recent commit message with `git-svn-id`, which is then processed by perl script that produces revision number and date, which are needed in build.xml.
In case _perl_ is not found, the build doesn't fail, values fallback to `UNKNOWN`, as specified in build.xml.
