### PR TITLE
Add tactile_paving combo to Pedestrian Crossing

### DIFF
--- a/data/defaultpresets.xml
+++ b/data/defaultpresets.xml
@@ -1309,6 +1309,8 @@
             <label text="In case of traffic signals:" />
             <check key="button_operated" text="Button operated" />
             <check key="traffic_signals:sound" text="Sound signals" />
+            <combo key="tactile_paving" text="Tactile Paving?" values="yes, no, primitive, incorrect"
+                   default="" delete_if_empty="true" />
         </item> <!-- Pedestrian Crossing -->
         <group name="Traffic Calming" icon="styles/standard/vehicle/choker.svg"> 
             <item name="Bump" icon="styles/standard/vehicle/bump.svg" type="node,way" preset_name_label="true">


### PR DESCRIPTION
Pedestrian Crossing preset is currently lacking `tactile_paving` key, which is very important on pedestrian crossing for visually impaired people and it is in fact recognized in the http://wiki.openstreetmap.org/wiki/Key:crossing defintion