### PR TITLE
Search compiler with GUI

### DIFF
--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -296,8 +296,6 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         bg2.add(regexSearch);
         bg2.add(mapCSSSearch);
 
-        JPanel left = new JPanel(new GridBagLayout());
-
         JPanel selectionSettings = new JPanel(new GridBagLayout());
         selectionSettings.setBorder(BorderFactory.createTitledBorder(tr("Selection settings")));
         selectionSettings.add(replace, GBC.eol().anchor(GBC.WEST).fill(GBC.HORIZONTAL));
@@ -308,6 +306,8 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         JPanel additionalSettings = new JPanel(new GridBagLayout());
         additionalSettings.setBorder(BorderFactory.createTitledBorder(tr("Additional settings")));
         additionalSettings.add(caseSensitive, GBC.eol().anchor(GBC.WEST).fill(GBC.HORIZONTAL));
+
+        JPanel left = new JPanel(new GridBagLayout());
 
         left.add(selectionSettings, GBC.eol().fill(GBC.BOTH));
         left.add(additionalSettings, GBC.eol().fill(GBC.BOTH));
@@ -333,7 +333,11 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         JTextComponent editorComponent = hcbSearchString.getEditorComponent();
         Document document = editorComponent.getDocument();
 
-        // Setup the logic to validate contents of the search text field.
+        /*
+         * Setup the logic to validate the contents of the search text field which is executed
+         * every time the content of the field has changed. If the query is incorrect, then
+         * the text field is colored red.
+         */
         document.addDocumentListener(new AbstractTextComponentValidator(editorComponent) {
 
             @Override

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -378,9 +378,8 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
 
         /*
          * Setup the logic to append preset queries to the search text field according to
-         * selected preset by the user in {@link TaggingPresetSelector}.
-         * Every query is of the form ' group/sub-group/presetName' if the correposing group
-         * of the preset exists, otherwise it is simply ' presetName'.
+         * selected preset by the user. Every query is of the form ' group/sub-group/presetName'
+         * if the corresponding group of the preset exists, otherwise it is simply ' presetName'.
          */
         TaggingPresetSelector selector = new TaggingPresetSelector(false, false);
         selector.setBorder(BorderFactory.createTitledBorder(tr("Search by preset")));

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -454,8 +454,8 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 .addKeyword("type:node", "type:node ", tr("all nodes"))
                 .addKeyword("type:way", "type:way ", tr("all ways"))
                 .addKeyword("type:relation", "type:relation ", tr("all relations"))
-                .addKeyword("preset:water", "preset:water", tr("all object that match the water preset"))
-                .addKeyword("preset:\"fast food\"", "preset:\"fast food\"", tr("all objects that match the fast food preset"))
+                .addKeyword("preset:water", "preset:water", tr("all objects that use the water preset"))
+                .addKeyword("preset:\"fast food\"", "preset:\"fast food\"", tr("all objects that use the fast food preset"))
                 .addKeyword("closed", "closed ", tr("all closed ways"))
                 .addKeyword("untagged", "untagged ", tr("object without useful tags")),
                 GBC.eol());

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -454,6 +454,8 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 .addKeyword("type:node", "type:node ", tr("all nodes"))
                 .addKeyword("type:way", "type:way ", tr("all ways"))
                 .addKeyword("type:relation", "type:relation ", tr("all relations"))
+                .addKeyword("preset:water", "preset:water", tr("all object that match the water preset"))
+                .addKeyword("preset:\"fast food\"", "preset:\"fast food\"", tr("all objects that match the fast food preset"))
                 .addKeyword("closed", "closed ", tr("all closed ways"))
                 .addKeyword("untagged", "untagged ", tr("object without useful tags")),
                 GBC.eol());

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -239,14 +239,20 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                         JTextComponent tf = hcb.getEditorComponent();
 
                         /*
-                         * Get the focus in order to select proper area within the search
-                         * text field if autocompletion triggered.
+                         * Make sure that the focus is transferred to the search text field
+                         * from the selector component.
                          */
                         if (!tf.hasFocus()) {
                             tf.requestFocusInWindow();
                         }
 
-                        // TODO: add docs why we use invokeLater here
+                         /*
+                         * In order to make interaction with the search dialog simpler,
+                         * we make sure that if autocompletion triggers and the text field is
+                         * not in focus, the correct area is selected. We first request focus
+                         * and then execute the selection logic. invokeLater allows us to
+                         * defer the selection until waiting for focus.
+                         */
                         SwingUtilities.invokeLater(() -> {
                             try {
                                 tf.getDocument().insertString(tf.getCaretPosition(), ' ' + insertText, null);

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -323,12 +323,10 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         top.add(label, GBC.std().insets(0, 0, 5, 0));
         top.add(hcbSearchString, GBC.eol().fill(GBC.HORIZONTAL));
 
-        /**
-         * Setup the logic to validate contents of the search text field.
-         */
         final JTextComponent editorComponent = hcbSearchString.getEditorComponent();
         final Document document = editorComponent.getDocument();
 
+        // Setup the logic to validate contents of the search text field.
         document.addDocumentListener(new AbstractTextComponentValidator(editorComponent) {
 
             @Override
@@ -356,9 +354,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             }
         });
 
-        /**
-         * Setup the logic to append preset queries to the search text field.
-         */
+        // Setup the logic to append preset queries to the search text field.
         final TaggingPresetSelector selector = new TaggingPresetSelector(false, false);
         selector.setBorder(BorderFactory.createTitledBorder(tr("Search by preset")));
 

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -245,6 +245,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                             tf.requestFocusInWindow();
                         }
 
+                        // TODO: add docs why we use invokeLater here
                         SwingUtilities.invokeLater(() -> {
                             try {
                                 tf.getDocument().insertString(tf.getCaretPosition(), ' ' + insertText, null);
@@ -397,6 +398,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
              */
             editorComponent.requestFocusInWindow();
 
+            // TODO: add docs why we use invokeLater here
             SwingUtilities.invokeLater(() -> {
                 int textOffset = editorComponent.getCaretPosition();
                 String presetSearchQuery = " preset:" +

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -235,12 +235,23 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
 
                     @Override
                     public void mouseClicked(MouseEvent e) {
-                        try {
-                            JTextComponent tf = hcb.getEditorComponent();
-                            tf.getDocument().insertString(tf.getCaretPosition(), ' ' + insertText, null);
-                        } catch (BadLocationException ex) {
-                            throw new JosmRuntimeException(ex.getMessage(), ex);
+                        JTextComponent tf = hcb.getEditorComponent();
+
+                        /*
+                         * Get the focus in order to select proper area within the search
+                         * text field if autocompletion triggered.
+                         */
+                        if (!tf.hasFocus()) {
+                            tf.requestFocusInWindow();
                         }
+
+                        SwingUtilities.invokeLater(() -> {
+                            try {
+                                tf.getDocument().insertString(tf.getCaretPosition(), ' ' + insertText, null);
+                            } catch (BadLocationException ex) {
+                                throw new JosmRuntimeException(ex.getMessage(), ex);
+                            }
+                        });
                     }
                 });
             }
@@ -382,7 +393,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             }
 
             /*
-             * Make sure that the focus is transfered to the search text field, in order
+             * Make sure that the focus is transferred to the search text field, in order
              * to allow the user simply delete autocompleted part of the query.
              */
             editorComponent.requestFocusInWindow();

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -361,7 +361,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             }
         });
 
-        /**
+        /*
          * Setup the logic to append preset queries to the search text field according to
          * selected preset by the user in {@link TaggingPresetSelector}.
          * Every query is of the form ' group/sub-group/presetName' if the correposing group
@@ -377,7 +377,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 return;
             }
 
-            /**
+            /*
              * Make sure that the focus is transfered to the search text field, in order
              * to allow the user simply delete autocompleted part of the query.
              */

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -245,7 +245,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                             tf.requestFocusInWindow();
                         }
 
-                         /*
+                        /*
                          * In order to make interaction with the search dialog simpler,
                          * we make sure that if autocompletion triggers and the text field is
                          * not in focus, the correct area is selected. We first request focus

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -378,7 +378,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
 
         /*
          * Setup the logic to append preset queries to the search text field according to
-         * selected preset by the user. Every query is of the form ' group/sub-group/presetName'
+         * selected preset by the user. Every query is of the form ' group/sub-group/.../presetName'
          * if the corresponding group of the preset exists, otherwise it is simply ' presetName'.
          */
         TaggingPresetSelector selector = new TaggingPresetSelector(false, false);

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -522,11 +522,16 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 .addKeyword("type:node", "type:node ", tr("all nodes"))
                 .addKeyword("type:way", "type:way ", tr("all ways"))
                 .addKeyword("type:relation", "type:relation ", tr("all relations"))
-                .addKeyword("preset:water", "preset:water", tr("all objects that use the water preset"))
-                .addKeyword("preset:\"fast food\"", "preset:\"fast food\"", tr("all objects that use the fast food preset"))
                 .addKeyword("closed", "closed ", tr("all closed ways"))
                 .addKeyword("untagged", "untagged ", tr("object without useful tags")),
                 GBC.eol());
+
+            hintPanel.add(new SearchKeywordRow(hcbSearchString)
+                    .addKeyword("preset:\"Annotation/Address\"", "preset:\"Annotation/Address\"",
+                            tr("all objects that use the address preset"))
+                    .addKeyword("preset:\"Geography/Nature/*\"", "preset:\"Geography/Nature/*\"",
+                            tr("all objects that use any preset under the Geography/Nature group")),
+                    GBC.eol().anchor(GBC.CENTER));
             hintPanel.add(new SearchKeywordRow(hcbSearchString)
                 .addTitle(tr("metadata"))
                 .addKeyword("user:", "user:", tr("objects changed by user", "user:anonymous"))

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -360,7 +360,12 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             }
         });
 
-        // Setup the logic to append preset queries to the search text field.
+        /**
+         * Setup the logic to append preset queries to the search text field according to
+         * selected preset by the user in {@link TaggingPresetSelector}.
+         * Every query is of the form ' group/sub-group/presetName' if the correposing group
+         * of the preset exists, otherwise it is simply ' presetName'.
+         */
         final TaggingPresetSelector selector = new TaggingPresetSelector(false, false);
         selector.setBorder(BorderFactory.createTitledBorder(tr("Search by preset")));
 
@@ -425,9 +430,14 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         if (dialog.showDialog().getValue() != 1) return null;
 
         // User pressed OK - let's perform the search
-        SearchMode mode = replace.isSelected() ? SearchAction.SearchMode.replace
-                : (add.isSelected() ? SearchAction.SearchMode.add
-                        : (remove.isSelected() ? SearchAction.SearchMode.remove : SearchAction.SearchMode.in_selection));
+        SearchMode mode = replace.isSelected()
+                ? SearchAction.SearchMode.replace
+                : (add.isSelected()
+                    ? SearchAction.SearchMode.add
+                    : (remove.isSelected()
+                        ? SearchAction.SearchMode.remove
+                        : SearchAction.SearchMode.in_selection));
+
         initialValues.text = hcbSearchString.getText();
         initialValues.mode = mode;
         initialValues.caseSensitive = caseSensitive.isSelected();
@@ -448,6 +458,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             // add custom search button to toolbar preferences
             Main.toolbar.addCustomButton(res, -1, false);
         }
+
         return initialValues;
     }
 

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -12,7 +12,6 @@ import java.awt.FlowLayout;
 import java.awt.GraphicsEnvironment;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -260,8 +260,8 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
 
         // prepare the combo box with the search expressions
         JLabel label = new JLabel(initialValues instanceof Filter ? tr("Filter string:") : tr("Search string:"));
-        final HistoryComboBox hcbSearchString = new HistoryComboBox();
-        final String tooltip = tr("Enter the search expression");
+        HistoryComboBox hcbSearchString = new HistoryComboBox();
+        String tooltip = tr("Enter the search expression");
         hcbSearchString.setText(initialValues.text);
         hcbSearchString.setToolTipText(tooltip);
 
@@ -282,15 +282,15 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         bg.add(remove);
         bg.add(inSelection);
 
-        final JCheckBox caseSensitive = new JCheckBox(tr("case sensitive"), initialValues.caseSensitive);
+        JCheckBox caseSensitive = new JCheckBox(tr("case sensitive"), initialValues.caseSensitive);
         JCheckBox allElements = new JCheckBox(tr("all objects"), initialValues.allElements);
         allElements.setToolTipText(tr("Also include incomplete and deleted objects in search."));
         JCheckBox addOnToolbar = new JCheckBox(tr("add toolbar button"), false);
 
-        final JRadioButton standardSearch = new JRadioButton(tr("standard"), !initialValues.regexSearch && !initialValues.mapCSSSearch);
-        final JRadioButton regexSearch = new JRadioButton(tr("regular expression"), initialValues.regexSearch);
-        final JRadioButton mapCSSSearch = new JRadioButton(tr("MapCSS selector"), initialValues.mapCSSSearch);
-        final ButtonGroup bg2 = new ButtonGroup();
+        JRadioButton standardSearch = new JRadioButton(tr("standard"), !initialValues.regexSearch && !initialValues.mapCSSSearch);
+        JRadioButton regexSearch = new JRadioButton(tr("regular expression"), initialValues.regexSearch);
+        JRadioButton mapCSSSearch = new JRadioButton(tr("MapCSS selector"), initialValues.mapCSSSearch);
+        ButtonGroup bg2 = new ButtonGroup();
         bg2.add(standardSearch);
         bg2.add(regexSearch);
         bg2.add(mapCSSSearch);
@@ -324,13 +324,13 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             left.add(searchOptions, GBC.eol().fill(GBC.BOTH));
         }
 
-        final JPanel right = SearchAction.buildHintsSection(hcbSearchString);
-        final JPanel top = new JPanel(new GridBagLayout());
+        JPanel right = SearchAction.buildHintsSection(hcbSearchString);
+        JPanel top = new JPanel(new GridBagLayout());
         top.add(label, GBC.std().insets(0, 0, 5, 0));
         top.add(hcbSearchString, GBC.eol().fill(GBC.HORIZONTAL));
 
-        final JTextComponent editorComponent = hcbSearchString.getEditorComponent();
-        final Document document = editorComponent.getDocument();
+        JTextComponent editorComponent = hcbSearchString.getEditorComponent();
+        Document document = editorComponent.getDocument();
 
         // Setup the logic to validate contents of the search text field.
         document.addDocumentListener(new AbstractTextComponentValidator(editorComponent) {
@@ -366,7 +366,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
          * Every query is of the form ' group/sub-group/presetName' if the correposing group
          * of the preset exists, otherwise it is simply ' presetName'.
          */
-        final TaggingPresetSelector selector = new TaggingPresetSelector(false, false);
+        TaggingPresetSelector selector = new TaggingPresetSelector(false, false);
         selector.setBorder(BorderFactory.createTitledBorder(tr("Search by preset")));
 
         selector.setDblClickListener(ev -> {
@@ -387,7 +387,7 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             }
         });
 
-        final JPanel p = new JPanel(new GridBagLayout());
+        JPanel p = new JPanel(new GridBagLayout());
         p.add(top, GBC.eol().fill(GBC.HORIZONTAL).insets(5, 5, 5, 0));
         p.add(left, GBC.std().anchor(GBC.NORTH).insets(5, 10, 10, 0).fill(GBC.VERTICAL));
         p.add(right, GBC.std().fill(GBC.BOTH).insets(0, 10, 0, 0));

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -525,7 +525,6 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 .addKeyword("closed", "closed ", tr("all closed ways"))
                 .addKeyword("untagged", "untagged ", tr("object without useful tags")),
                 GBC.eol());
-
             hintPanel.add(new SearchKeywordRow(hcbSearchString)
                     .addKeyword("preset:\"Annotation/Address\"", "preset:\"Annotation/Address\"",
                             tr("all objects that use the address preset"))

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -454,20 +454,21 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         if (dialog.showDialog().getValue() != 1) return null;
 
         // User pressed OK - let's perform the search
-        SearchMode mode = replace.isSelected()
-                ? SearchAction.SearchMode.replace
-                : (add.isSelected()
-                    ? SearchAction.SearchMode.add
-                    : (remove.isSelected()
-                        ? SearchAction.SearchMode.remove
-                        : SearchAction.SearchMode.in_selection));
-
         initialValues.text = hcbSearchString.getText();
-        initialValues.mode = mode;
         initialValues.caseSensitive = caseSensitive.isSelected();
         initialValues.allElements = allElements.isSelected();
         initialValues.regexSearch = regexSearch.isSelected();
         initialValues.mapCSSSearch = mapCSSSearch.isSelected();
+
+        if (inSelection.isSelected()) {
+            initialValues.mode = SearchAction.SearchMode.in_selection;
+        } else if (replace.isSelected()) {
+            initialValues.mode = SearchAction.SearchMode.replace;
+        } else if (add.isSelected()) {
+            initialValues.mode = SearchAction.SearchMode.add;
+        } else {
+            initialValues.mode = SearchAction.SearchMode.remove;
+        }
 
         if (addOnToolbar.isSelected()) {
             ToolbarPreferences.ActionDefinition aDef =

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -35,6 +35,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
@@ -376,15 +377,22 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
                 return;
             }
 
-            int textOffset = editorComponent.getCaretPosition();
+            /**
+             * Make sure that the focus is transfered to the search text field, in order
+             * to allow the user simply delete autocompleted part of the query.
+             */
+            editorComponent.requestFocusInWindow();
 
-            try {
-                final String presetSearchQuery = " preset:" +
+            SwingUtilities.invokeLater(() -> {
+                int textOffset = editorComponent.getCaretPosition();
+                String presetSearchQuery = " preset:" +
                         "\"" + selectedPreset.getRawName() + "\"";
-                document.insertString(textOffset, presetSearchQuery, null);
-            } catch (BadLocationException e) {
-                throw new JosmRuntimeException(e.getMessage(), e);
-            }
+                try {
+                    document.insertString(textOffset, presetSearchQuery, null);
+                } catch (BadLocationException e1) {
+                    throw new JosmRuntimeException(e1.getMessage(), e1);
+                }
+            });
         });
 
         JPanel p = new JPanel(new GridBagLayout());

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -247,12 +247,18 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         }
     }
 
+    /**
+     * Builds and shows the search dialog.
+     * @param initialValues A set of initial values needed in order to initialize the search dialog.
+     *                      If is {@code null}, then default settings are used.
+     * @return Returns {@link SearchAction} object containing parameters of the search.
+     */
     public static SearchSetting showSearchDialog(SearchSetting initialValues) {
         if (initialValues == null) {
             initialValues = new SearchSetting();
         }
-        // -- prepare the combo box with the search expressions
-        //
+
+        // prepare the combo box with the search expressions
         JLabel label = new JLabel(initialValues instanceof Filter ? tr("Filter string:") : tr("Search string:"));
         final HistoryComboBox hcbSearchString = new HistoryComboBox();
         final String tooltip = tr("Enter the search expression");

--- a/src/org/openstreetmap/josm/actions/search/SearchAction.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchAction.java
@@ -845,6 +845,10 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
         }
     }
 
+    /**
+     * This class defines a set of parameters that is used to
+     * perform search within the search dialog.
+     */
     public static class SearchSetting {
         public String text;
         public SearchMode mode;
@@ -906,6 +910,24 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             return Objects.hash(text, mode, caseSensitive, regexSearch, mapCSSSearch, allElements);
         }
 
+        /**
+         * <p>Transforms a string following a certain format, namely "[R | A | D | S][C?,R?,A?,M?] [a-zA-Z]"
+         * where the first part defines the mode of the search, see {@link SearchMode}, the second defines
+         * a set of attributes within the {@code SearchSetting} class and the second is the search query.
+         * <p>
+         * Attributes are as follows:
+         * <ul>
+         *     <li>C - if search is case sensitive
+         *     <li>R - if the regex syntax is used
+         *     <li>A - if all objects are considered
+         *     <li>M - if the mapCSS syntax is used
+         * </ul>
+         * <p>For example, "RC type:node" is a valid string representation of an object that replaces the
+         * current selection, is case sensitive and searches for all objects of type node.
+         * @param s A string representation of a {@code SearchSetting} object
+         *          from which the object must be built.
+         * @return A {@code SearchSetting} defined by the input string.
+         */
         public static SearchSetting readFromString(String s) {
             if (s.isEmpty())
                 return null;
@@ -947,6 +969,11 @@ public class SearchAction extends JosmAction implements ParameterizedAction {
             return result;
         }
 
+        /**
+         * Builds a string representation of the {@code SearchSetting} object,
+         * see {@link #readFromString(String)} for more details.
+         * @return A string representation of the {@code SearchSetting} object.
+         */
         public String writeToString() {
             if (text == null || text.isEmpty())
                 return "";

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -20,7 +20,6 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.search.PushbackTokenizer.Range;
@@ -78,7 +77,6 @@ public class SearchCompiler {
     private static Map<String, SimpleMatchFactory> simpleMatchFactoryMap = new HashMap<>();
     private static Map<String, UnaryMatchFactory> unaryMatchFactoryMap = new HashMap<>();
     private static Map<String, BinaryMatchFactory> binaryMatchFactoryMap = new HashMap<>();
-//    private static Map<String, List<TaggingPreset>> presets;
 
     public SearchCompiler(boolean caseSensitive, boolean regexSearch, PushbackTokenizer tokenizer) {
         this.caseSensitive = caseSensitive;
@@ -92,11 +90,6 @@ public class SearchCompiler {
         if (unaryMatchFactoryMap.isEmpty()) {
             addMatchFactory(new CoreUnaryMatchFactory());
         }
-        // register a listener to react on any change made on the list of presets
-//        if (presets == null) {
-//            loadPresets();
-//            TaggingPresets.addListener(SearchCompiler::loadPresets);
-//        }
     }
 
     /**
@@ -118,13 +111,6 @@ public class SearchCompiler {
                 Main.warn("SearchCompiler: for key ''{0}'', overriding match factory ''{1}'' with ''{2}''", keyword, existing, factory);
             }
         }
-    }
-
-    private static void loadPresets() {
-//        presets = TaggingPresets.getTaggingPresets()
-//                .stream()
-//                .filter(p -> p.getSimpleName() != null)
-//                .collect(Collectors.groupingBy(p -> p.name));
     }
 
     public class CoreSimpleMatchFactory implements SimpleMatchFactory {
@@ -1583,17 +1569,15 @@ public class SearchCompiler {
             if (presetName == null)
                 throw new ParseError("Preset name cannot be null");
 
-//            this.ps = SearchCompiler.presets.get(presetName);
             Collection<TaggingPreset> ts = TaggingPresets.getTaggingPresets();
-            ps = new ArrayList<TaggingPreset>(ts.size());
+            ps = new ArrayList<>();
 
             for (TaggingPreset t : ts) {
                 String name = t.getSimpleName();
 
-                if (name != null && name.equals(presetName)) ps.add(t);
+                if (name != null && name.equalsIgnoreCase(presetName)) ps.add(t);
             }
 
-//            if (ps == null)
             if (ps.isEmpty())
                 throw new ParseError(tr("Unknown preset name: ") + presetName);
         }

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -1564,7 +1564,7 @@ public class SearchCompiler {
     private static class Preset extends Match {
         private List<TaggingPreset> ps;
 
-        public Preset(String presetName) throws ParseError{
+        Preset(String presetName) throws ParseError {
 
             if (presetName == null)
                 throw new ParseError("Preset name cannot be null");

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -1572,6 +1572,22 @@ public class SearchCompiler {
         }
     }
 
+    /**
+     * Matches presets.
+     */
+    private static class Preset extends Match {
+        private TaggingPreset preset;
+
+        public Preset(TaggingPreset p){
+            this.preset = p;
+        }
+
+        @Override
+        public boolean match(OsmPrimitive osm) {
+            return preset.test(osm);
+        }
+    }
+
     public static class ParseError extends Exception {
         public ParseError(String msg) {
             super(msg);

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -1605,18 +1605,18 @@ public class SearchCompiler {
         }
 
         private boolean presetNameMatch(String name, TaggingPreset preset, boolean matchStrictly) {
-            // there is no wildcard
             if (matchStrictly) {
                 return name.equalsIgnoreCase(preset.getRawName());
             }
 
-            String groupSuffix = null;
-            
-            if (name.equals("*") && (groupSuffix = name.substring(0, name.length() - 2)).equals("")) {
+            try {
+                String groupSuffix = name.substring(0, name.length() - 2); // try to remove '/*'
+                TaggingPresetMenu group = preset.group;
+
+                return group != null && groupSuffix.equalsIgnoreCase(group.getRawName());
+            } catch (StringIndexOutOfBoundsException ex) {
                 return false;
             }
-
-            return preset.group != null && preset.group.getRawName().equalsIgnoreCase(groupSuffix);
         }
     }
 

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -21,7 +21,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
-import java.util.Objects;
 
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.search.PushbackTokenizer.Range;

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -78,7 +78,7 @@ public class SearchCompiler {
     private static Map<String, SimpleMatchFactory> simpleMatchFactoryMap = new HashMap<>();
     private static Map<String, UnaryMatchFactory> unaryMatchFactoryMap = new HashMap<>();
     private static Map<String, BinaryMatchFactory> binaryMatchFactoryMap = new HashMap<>();
-    private static Map<String, List<TaggingPreset>> presets;
+//    private static Map<String, List<TaggingPreset>> presets;
 
     public SearchCompiler(boolean caseSensitive, boolean regexSearch, PushbackTokenizer tokenizer) {
         this.caseSensitive = caseSensitive;
@@ -93,10 +93,10 @@ public class SearchCompiler {
             addMatchFactory(new CoreUnaryMatchFactory());
         }
         // register a listener to react on any change made on the list of presets
-        if (presets == null || presets.isEmpty()) {
-            TaggingPresets.addListener(SearchCompiler::loadPresets);
-            loadPresets();
-        }
+//        if (presets == null) {
+//            loadPresets();
+//            TaggingPresets.addListener(SearchCompiler::loadPresets);
+//        }
     }
 
     /**
@@ -121,10 +121,10 @@ public class SearchCompiler {
     }
 
     private static void loadPresets() {
-        presets = TaggingPresets.getTaggingPresets()
-                .stream()
-                .filter(p -> p.getSimpleName() != null)
-                .collect(Collectors.groupingBy(p -> p.name));
+//        presets = TaggingPresets.getTaggingPresets()
+//                .stream()
+//                .filter(p -> p.getSimpleName() != null)
+//                .collect(Collectors.groupingBy(p -> p.name));
     }
 
     public class CoreSimpleMatchFactory implements SimpleMatchFactory {
@@ -1583,9 +1583,18 @@ public class SearchCompiler {
             if (presetName == null)
                 throw new ParseError("Preset name cannot be null");
 
-            this.ps = SearchCompiler.presets.get(presetName);
+//            this.ps = SearchCompiler.presets.get(presetName);
+            Collection<TaggingPreset> ts = TaggingPresets.getTaggingPresets();
+            ps = new ArrayList<TaggingPreset>(ts.size());
 
-            if (ps == null)
+            for (TaggingPreset t : ts) {
+                String name = t.getSimpleName();
+
+                if (name != null && name.equals(presetName)) ps.add(t);
+            }
+
+//            if (ps == null)
+            if (ps.isEmpty())
                 throw new ParseError(tr("Unknown preset name: ") + presetName);
         }
 

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -1568,7 +1568,9 @@ public class SearchCompiler {
 
         Preset(String presetName) throws ParseError {
 
-            Objects.requireNonNull(presetName);
+            if (presetName == null) {
+                throw new ParseError("The name of the preset is required");
+            }
 
             this.presets = TaggingPresets.getTaggingPresets()
                     .stream()

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -1610,24 +1610,13 @@ public class SearchCompiler {
                 return name.equalsIgnoreCase(preset.getRawName());
             }
 
-            // match any preset
-            if (name.equals("*")) {
-                return true;
-            }
-
-            // remove '/*' and try to match the group name
-            String groupSuffix = name.substring(0, name.length() - 2);
-
-            if (groupSuffix.equals("")) {
+            String groupSuffix = null;
+            
+            if (name.equals("*") && (groupSuffix = name.substring(0, name.length() - 2)).equals("")) {
                 return false;
             }
 
-            TaggingPreset group = preset.group;
-            if (group != null) {
-                return group.getRawName().equalsIgnoreCase(groupSuffix);
-            }
-
-            return false;
+            return preset.group != null && preset.group.getRawName().equalsIgnoreCase(groupSuffix);
         }
     }
 

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -40,6 +40,8 @@ import org.openstreetmap.josm.gui.mappaint.mapcss.Selector;
 import org.openstreetmap.josm.gui.mappaint.mapcss.parsergen.MapCSSParser;
 import org.openstreetmap.josm.gui.mappaint.mapcss.parsergen.ParseException;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetMenu;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetSeparator;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresets;
 import org.openstreetmap.josm.tools.AlphanumComparator;
 import org.openstreetmap.josm.tools.Geometry;
@@ -1573,6 +1575,7 @@ public class SearchCompiler {
 
             Optional<TaggingPreset> p = TaggingPresets.getTaggingPresets()
                     .stream()
+                    .filter(preset -> !(preset instanceof TaggingPresetMenu))
                     .filter(preset -> presetName.equalsIgnoreCase(preset.getRawName()))
                     .findFirst();
 

--- a/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/actions/search/SearchCompiler.java
@@ -123,7 +123,7 @@ public class SearchCompiler {
     private static void loadPresets() {
         presets = TaggingPresets.getTaggingPresets()
                 .stream()
-                .filter(p -> p.name != null)
+                .filter(p -> p.getSimpleName() != null)
                 .collect(Collectors.groupingBy(p -> p.name));
     }
 
@@ -1579,13 +1579,20 @@ public class SearchCompiler {
         private List<TaggingPreset> ps;
 
         public Preset(String presetName) throws ParseError{
-            this.ps = SearchCompiler.presets
-                    .get(presetName);
+
+            if (presetName == null)
+                throw new ParseError("Preset name cannot be null");
+
+            this.ps = SearchCompiler.presets.get(presetName);
 
             if (ps == null)
                 throw new ParseError(tr("Unknown preset name: ") + presetName);
         }
 
+        /**
+         * Since presets can have common names, the primitive is considered to
+         * belong to a certain preset if it matches at least one of them.
+         */
         @Override
         public boolean match(OsmPrimitive osm) {
             for (TaggingPreset p : ps) {

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
@@ -173,6 +173,12 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
     }
 
     /**
+     * Returns the non translated name without any prefixes.
+     * @return returns the non translated name without any prefixes.
+     */
+    public String getSimpleName() { return this.name; }
+
+    /**
      * Returns the preset icon (16px).
      * @return The preset icon, or {@code null} if none defined
      * @since 6403

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
@@ -176,7 +176,9 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
      * Returns the non translated name without any prefixes.
      * @return returns the non translated name without any prefixes.
      */
-    public String getSimpleName() { return this.name; }
+    public String getSimpleName() {
+        return this.name;
+    }
 
     /**
      * Returns the preset icon (16px).

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
@@ -173,14 +173,6 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
     }
 
     /**
-     * Returns the non translated name without any prefixes.
-     * @return returns the non translated name without any prefixes.
-     */
-    public String getSimpleName() {
-        return this.name;
-    }
-
-    /**
      * Returns the preset icon (16px).
      * @return The preset icon, or {@code null} if none defined
      * @since 6403

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSelector.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSelector.java
@@ -66,11 +66,169 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
     private boolean typesInSelectionDirty = true;
     private final transient PresetClassifications classifications = new PresetClassifications();
 
+    /**
+     * Constructs a new {@code TaggingPresetSelector}.
+     * @param displayOnlyApplicable if {@code true} display "Show only applicable to selection" checkbox
+     * @param displaySearchInTags if {@code true} display "Search in tags" checkbox
+     */
+    public TaggingPresetSelector(boolean displayOnlyApplicable, boolean displaySearchInTags) {
+        super();
+        lsResult.setCellRenderer(new ResultListCellRenderer());
+        classifications.loadPresets(TaggingPresets.getTaggingPresets());
+
+        JPanel pnChecks = new JPanel();
+        pnChecks.setLayout(new BoxLayout(pnChecks, BoxLayout.Y_AXIS));
+
+        if (displayOnlyApplicable) {
+            ckOnlyApplicable = new JCheckBox();
+            ckOnlyApplicable.setText(tr("Show only applicable to selection"));
+            pnChecks.add(ckOnlyApplicable);
+            ckOnlyApplicable.addItemListener(e -> filterItems());
+        } else {
+            ckOnlyApplicable = null;
+        }
+
+        if (displaySearchInTags) {
+            ckSearchInTags = new JCheckBox();
+            ckSearchInTags.setText(tr("Search in tags"));
+            ckSearchInTags.setSelected(SEARCH_IN_TAGS.get());
+            ckSearchInTags.addItemListener(e -> filterItems());
+            pnChecks.add(ckSearchInTags);
+        } else {
+            ckSearchInTags = null;
+        }
+
+        add(pnChecks, BorderLayout.SOUTH);
+
+        setPreferredSize(new Dimension(400, 300));
+        filterItems();
+        JPopupMenu popupMenu = new JPopupMenu();
+        popupMenu.add(new AbstractAction(tr("Add toolbar button")) {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                final TaggingPreset preset = getSelectedPreset();
+                if (preset != null) {
+                    Main.toolbar.addCustomButton(preset.getToolbarString(), -1, false);
+                }
+            }
+        });
+        lsResult.addMouseListener(new PopupMenuLauncher(popupMenu));
+    }
+
+    /**
+     * Search expression can be in form: "group1/group2/name" where names can contain multiple words
+     */
+    @Override
+    protected synchronized void filterItems() {
+        //TODO Save favorites to file
+        String text = edSearchText.getText().toLowerCase(Locale.ENGLISH);
+        boolean onlyApplicable = ckOnlyApplicable != null && ckOnlyApplicable.isSelected();
+        boolean inTags = ckSearchInTags != null && ckSearchInTags.isSelected();
+
+        DataSet ds = Main.getLayerManager().getEditDataSet();
+        Collection<OsmPrimitive> selected = (ds == null) ? Collections.<OsmPrimitive>emptyList() : ds.getSelected();
+        final List<PresetClassification> result = classifications.getMatchingPresets(
+                text, onlyApplicable, inTags, getTypesInSelection(), selected);
+
+        final TaggingPreset oldPreset = getSelectedPreset();
+        lsResultModel.setItems(Utils.transform(result, x -> x.preset));
+        final TaggingPreset newPreset = getSelectedPreset();
+        if (!Objects.equals(oldPreset, newPreset)) {
+            int[] indices = lsResult.getSelectedIndices();
+            for (ListSelectionListener listener : listSelectionListeners) {
+                listener.valueChanged(new ListSelectionEvent(lsResult, lsResult.getSelectedIndex(),
+                        indices.length > 0 ? indices[indices.length-1] : -1, false));
+            }
+        }
+    }
+
+    private Set<TaggingPresetType> getTypesInSelection() {
+        if (typesInSelectionDirty) {
+            synchronized (typesInSelection) {
+                typesInSelectionDirty = false;
+                typesInSelection.clear();
+                if (Main.main == null || Main.getLayerManager().getEditDataSet() == null) return typesInSelection;
+                for (OsmPrimitive primitive : Main.getLayerManager().getEditDataSet().getSelected()) {
+                    typesInSelection.add(TaggingPresetType.forPrimitive(primitive));
+                }
+            }
+        }
+        return typesInSelection;
+    }
+
+    @Override
+    public void selectionChanged(Collection<? extends OsmPrimitive> newSelection) {
+        typesInSelectionDirty = true;
+    }
+
+    @Override
+    public synchronized void init() {
+        if (ckOnlyApplicable != null) {
+            ckOnlyApplicable.setEnabled(!getTypesInSelection().isEmpty());
+            ckOnlyApplicable.setSelected(!getTypesInSelection().isEmpty() && ONLY_APPLICABLE.get());
+        }
+        super.init();
+    }
+
+    public void init(Collection<TaggingPreset> presets) {
+        classifications.clear();
+        classifications.loadPresets(presets);
+        init();
+    }
+
+    /**
+     * Save checkbox values in preferences for future reuse
+     */
+    public void savePreferences() {
+        if (ckSearchInTags != null) {
+            SEARCH_IN_TAGS.put(ckSearchInTags.isSelected());
+        }
+        if (ckOnlyApplicable != null && ckOnlyApplicable.isEnabled()) {
+            ONLY_APPLICABLE.put(ckOnlyApplicable.isSelected());
+        }
+    }
+
+    /**
+     * Determines, which preset is selected at the moment.
+     * @return selected preset (as action)
+     */
+    public synchronized TaggingPreset getSelectedPreset() {
+        if (lsResultModel.isEmpty()) return null;
+        int idx = lsResult.getSelectedIndex();
+        if (idx < 0 || idx >= lsResultModel.getSize()) {
+            idx = 0;
+        }
+        return lsResultModel.getElementAt(idx);
+    }
+
+    /**
+     * Determines, which preset is selected at the moment. Updates {@link PresetClassification#favoriteIndex}!
+     * @return selected preset (as action)
+     */
+    public synchronized TaggingPreset getSelectedPresetAndUpdateClassification() {
+        final TaggingPreset preset = getSelectedPreset();
+        for (PresetClassification pc: classifications) {
+            if (pc.preset == preset) {
+                pc.favoriteIndex = CLASSIFICATION_IN_FAVORITES;
+            } else if (pc.favoriteIndex > 0) {
+                pc.favoriteIndex--;
+            }
+        }
+        return preset;
+    }
+
+    public synchronized void setSelectedPreset(TaggingPreset p) {
+        lsResult.setSelectedValue(p, true);
+    }
+
+    /**
+     * TODO: add docs
+     */
     private static class ResultListCellRenderer implements ListCellRenderer<TaggingPreset> {
         private final DefaultListCellRenderer def = new DefaultListCellRenderer();
         @Override
         public Component getListCellRendererComponent(JList<? extends TaggingPreset> list, TaggingPreset tp, int index,
-                boolean isSelected, boolean cellHasFocus) {
+                                                      boolean isSelected, boolean cellHasFocus) {
             JLabel result = (JLabel) def.getListCellRendererComponent(list, tp, index, isSelected, cellHasFocus);
             result.setText(tp.getName());
             result.setIcon((Icon) tp.getValue(Action.SMALL_ICON));
@@ -176,82 +334,6 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
     }
 
     /**
-     * Constructs a new {@code TaggingPresetSelector}.
-     * @param displayOnlyApplicable if {@code true} display "Show only applicable to selection" checkbox
-     * @param displaySearchInTags if {@code true} display "Search in tags" checkbox
-     */
-    public TaggingPresetSelector(boolean displayOnlyApplicable, boolean displaySearchInTags) {
-        super();
-        lsResult.setCellRenderer(new ResultListCellRenderer());
-        classifications.loadPresets(TaggingPresets.getTaggingPresets());
-
-        JPanel pnChecks = new JPanel();
-        pnChecks.setLayout(new BoxLayout(pnChecks, BoxLayout.Y_AXIS));
-
-        if (displayOnlyApplicable) {
-            ckOnlyApplicable = new JCheckBox();
-            ckOnlyApplicable.setText(tr("Show only applicable to selection"));
-            pnChecks.add(ckOnlyApplicable);
-            ckOnlyApplicable.addItemListener(e -> filterItems());
-        } else {
-            ckOnlyApplicable = null;
-        }
-
-        if (displaySearchInTags) {
-            ckSearchInTags = new JCheckBox();
-            ckSearchInTags.setText(tr("Search in tags"));
-            ckSearchInTags.setSelected(SEARCH_IN_TAGS.get());
-            ckSearchInTags.addItemListener(e -> filterItems());
-            pnChecks.add(ckSearchInTags);
-        } else {
-            ckSearchInTags = null;
-        }
-
-        add(pnChecks, BorderLayout.SOUTH);
-
-        setPreferredSize(new Dimension(400, 300));
-        filterItems();
-        JPopupMenu popupMenu = new JPopupMenu();
-        popupMenu.add(new AbstractAction(tr("Add toolbar button")) {
-            @Override
-            public void actionPerformed(ActionEvent ae) {
-                final TaggingPreset preset = getSelectedPreset();
-                if (preset != null) {
-                    Main.toolbar.addCustomButton(preset.getToolbarString(), -1, false);
-                }
-            }
-        });
-        lsResult.addMouseListener(new PopupMenuLauncher(popupMenu));
-    }
-
-    /**
-     * Search expression can be in form: "group1/group2/name" where names can contain multiple words
-     */
-    @Override
-    protected synchronized void filterItems() {
-        //TODO Save favorites to file
-        String text = edSearchText.getText().toLowerCase(Locale.ENGLISH);
-        boolean onlyApplicable = ckOnlyApplicable != null && ckOnlyApplicable.isSelected();
-        boolean inTags = ckSearchInTags != null && ckSearchInTags.isSelected();
-
-        DataSet ds = Main.getLayerManager().getEditDataSet();
-        Collection<OsmPrimitive> selected = (ds == null) ? Collections.<OsmPrimitive>emptyList() : ds.getSelected();
-        final List<PresetClassification> result = classifications.getMatchingPresets(
-                text, onlyApplicable, inTags, getTypesInSelection(), selected);
-
-        final TaggingPreset oldPreset = getSelectedPreset();
-        lsResultModel.setItems(Utils.transform(result, x -> x.preset));
-        final TaggingPreset newPreset = getSelectedPreset();
-        if (!Objects.equals(oldPreset, newPreset)) {
-            int[] indices = lsResult.getSelectedIndices();
-            for (ListSelectionListener listener : listSelectionListeners) {
-                listener.valueChanged(new ListSelectionEvent(lsResult, lsResult.getSelectedIndex(),
-                        indices.length > 0 ? indices[indices.length-1] : -1, false));
-            }
-        }
-    }
-
-    /**
      * A collection of {@link PresetClassification}s with the functionality of filtering wrt. searchString.
      */
     public static class PresetClassifications implements Iterable<PresetClassification> {
@@ -259,7 +341,7 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
         private final List<PresetClassification> classifications = new ArrayList<>();
 
         public List<PresetClassification> getMatchingPresets(String searchText, boolean onlyApplicable, boolean inTags,
-                Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
+                                                             Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
             final String[] groupWords;
             final String[] nameWords;
 
@@ -275,7 +357,7 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
         }
 
         public List<PresetClassification> getMatchingPresets(String[] groupWords, String[] nameWords, boolean onlyApplicable,
-                boolean inTags, Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
+                                                             boolean inTags, Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
 
             final List<PresetClassification> result = new ArrayList<>();
             for (PresetClassification presetClassification : classifications) {
@@ -347,84 +429,5 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
         public Iterator<PresetClassification> iterator() {
             return classifications.iterator();
         }
-    }
-
-    private Set<TaggingPresetType> getTypesInSelection() {
-        if (typesInSelectionDirty) {
-            synchronized (typesInSelection) {
-                typesInSelectionDirty = false;
-                typesInSelection.clear();
-                if (Main.main == null || Main.getLayerManager().getEditDataSet() == null) return typesInSelection;
-                for (OsmPrimitive primitive : Main.getLayerManager().getEditDataSet().getSelected()) {
-                    typesInSelection.add(TaggingPresetType.forPrimitive(primitive));
-                }
-            }
-        }
-        return typesInSelection;
-    }
-
-    @Override
-    public void selectionChanged(Collection<? extends OsmPrimitive> newSelection) {
-        typesInSelectionDirty = true;
-    }
-
-    @Override
-    public synchronized void init() {
-        if (ckOnlyApplicable != null) {
-            ckOnlyApplicable.setEnabled(!getTypesInSelection().isEmpty());
-            ckOnlyApplicable.setSelected(!getTypesInSelection().isEmpty() && ONLY_APPLICABLE.get());
-        }
-        super.init();
-    }
-
-    public void init(Collection<TaggingPreset> presets) {
-        classifications.clear();
-        classifications.loadPresets(presets);
-        init();
-    }
-
-    /**
-     * Save checkbox values in preferences for future reuse
-     */
-    public void savePreferences() {
-        if (ckSearchInTags != null) {
-            SEARCH_IN_TAGS.put(ckSearchInTags.isSelected());
-        }
-        if (ckOnlyApplicable != null && ckOnlyApplicable.isEnabled()) {
-            ONLY_APPLICABLE.put(ckOnlyApplicable.isSelected());
-        }
-    }
-
-    /**
-     * Determines, which preset is selected at the moment.
-     * @return selected preset (as action)
-     */
-    public synchronized TaggingPreset getSelectedPreset() {
-        if (lsResultModel.isEmpty()) return null;
-        int idx = lsResult.getSelectedIndex();
-        if (idx < 0 || idx >= lsResultModel.getSize()) {
-            idx = 0;
-        }
-        return lsResultModel.getElementAt(idx);
-    }
-
-    /**
-     * Determines, which preset is selected at the moment. Updates {@link PresetClassification#favoriteIndex}!
-     * @return selected preset (as action)
-     */
-    public synchronized TaggingPreset getSelectedPresetAndUpdateClassification() {
-        final TaggingPreset preset = getSelectedPreset();
-        for (PresetClassification pc: classifications) {
-            if (pc.preset == preset) {
-                pc.favoriteIndex = CLASSIFICATION_IN_FAVORITES;
-            } else if (pc.favoriteIndex > 0) {
-                pc.favoriteIndex--;
-            }
-        }
-        return preset;
-    }
-
-    public synchronized void setSelectedPreset(TaggingPreset p) {
-        lsResult.setSelectedValue(p, true);
     }
 }

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSelector.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSelector.java
@@ -340,8 +340,11 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
 
         private final List<PresetClassification> classifications = new ArrayList<>();
 
-        public List<PresetClassification> getMatchingPresets(String searchText, boolean onlyApplicable, boolean inTags,
-                                                             Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
+        public List<PresetClassification> getMatchingPresets(String searchText,
+                                                             boolean onlyApplicable,
+                                                             boolean inTags,
+                                                             Set<TaggingPresetType> presetTypes,
+                                                             final Collection<? extends OsmPrimitive> selectedPrimitives) {
             final String[] groupWords;
             final String[] nameWords;
 
@@ -356,8 +359,12 @@ public class TaggingPresetSelector extends SearchTextResultListPanel<TaggingPres
             return getMatchingPresets(groupWords, nameWords, onlyApplicable, inTags, presetTypes, selectedPrimitives);
         }
 
-        public List<PresetClassification> getMatchingPresets(String[] groupWords, String[] nameWords, boolean onlyApplicable,
-                                                             boolean inTags, Set<TaggingPresetType> presetTypes, final Collection<? extends OsmPrimitive> selectedPrimitives) {
+        public List<PresetClassification> getMatchingPresets(String[] groupWords,
+                                                             String[] nameWords,
+                                                             boolean onlyApplicable,
+                                                             boolean inTags,
+                                                             Set<TaggingPresetType> presetTypes,
+                                                             final Collection<? extends OsmPrimitive> selectedPrimitives) {
 
             final List<PresetClassification> result = new ArrayList<>();
             for (PresetClassification presetClassification : classifications) {

--- a/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
@@ -571,7 +571,7 @@ public class SearchCompilerTest {
         };
 
         for (int i = 0; i < queries.length; i++) {
-            SearchContext ctx = new SearchContext("preset:" + presetName);
+            SearchContext ctx = new SearchContext(queries[i]);
             ctx.n1.put(key, val);
             ctx.n2.put(key, val);
 

--- a/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +31,8 @@ import org.openstreetmap.josm.data.osm.Tag;
 import org.openstreetmap.josm.data.osm.User;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.WayData;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresets;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 import org.openstreetmap.josm.tools.date.DateUtils;
 
@@ -489,5 +492,51 @@ public class SearchCompilerTest {
     @Test
     public void testEnumExactKeyValueMode() {
         TestUtils.superficialEnumCodeCoverage(ExactKeyValue.Mode.class);
+    }
+
+    /**
+     * Robustness test for preset searching. Ensures that the query 'preset:' is not accepted.
+     * @throws ParseError always
+     */
+    @Test(expected = ParseError.class)
+    public void testPresetSearchMissingValue() throws ParseError {
+        SearchSetting settings = new SearchSetting();
+        settings.text = "preset:";
+        settings.mapCSSSearch = false;
+
+        SearchCompiler.compile(settings);
+    }
+
+    /**
+     * Robustness test for preset searching. Validates that it is not possible to search for
+     * non existing presets.
+     * @throws ParseError always
+     */
+    @Test(expected = ParseError.class)
+    public void testPresetNotExist() throws ParseError {
+        String testPresetName = "namethatshouldnotexist";
+        SearchSetting settings = new SearchSetting();
+        settings.text = "preset:" + testPresetName;
+        settings.mapCSSSearch = false;
+
+        // load presets
+        TaggingPresets.readFromPreferences();
+
+        SearchCompiler.compile(settings);
+    }
+
+    /**
+     * Robustness tests for preset searching. Ensures that combined presed names (having more than
+     * 1 words) must be enclosed in " .
+     * @throws ParseError always
+     */
+    @Test(expected = ParseError.class)
+    public void testPresetMultipleWords() throws ParseError{
+        String combinedPresetname = "Fast Food";
+        SearchSetting settings = new SearchSetting();
+        settings.text = "preset:" + combinedPresetname;
+        settings.mapCSSSearch = false;
+
+        SearchCompiler.compile(settings);
     }
 }

--- a/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/search/SearchCompilerTest.java
@@ -539,7 +539,7 @@ public class SearchCompilerTest {
      * @throws ParseError always
      */
     @Test(expected = ParseError.class)
-    public void testPresetMultipleWords() throws ParseError{
+    public void testPresetMultipleWords() throws ParseError {
         TaggingPreset testPreset = new TaggingPreset();
         testPreset.name = "Test Combined Preset Name";
         testPreset.group = new TaggingPresetMenu();
@@ -671,11 +671,11 @@ public class SearchCompilerTest {
         ctx.n1.put(key, val);
         ctx.n2.put(key, val);
 
-        for (OsmPrimitive osm : new OsmPrimitive[] { ctx.n1, ctx.n2 }) {
+        for (OsmPrimitive osm : new OsmPrimitive[] {ctx.n1, ctx.n2}) {
             ctx.match(osm, true);
         }
 
-        for (OsmPrimitive osm : new OsmPrimitive[] { ctx.r1, ctx.r2, ctx.w1, ctx.w2 }) {
+        for (OsmPrimitive osm : new OsmPrimitive[] {ctx.r1, ctx.r2, ctx.w1, ctx.w2}) {
             ctx.match(osm, false);
         }
     }


### PR DESCRIPTION
> Refactored the code a bit, made it more readable
    >> removed redundant final keywords from showSearchDialog()
    >> some small style changes
> Added a list of existing presets.
    >> Double clicking on any item from the list results in changes for a query in the search text field. Also, after dbl clicking the focus is moved to the text field. This is to fight autocompletion issues of the text field.
    >> Localization of preset names in the list is not an issue
> Extended the compiler to search for presets
    >> Search by presets complete name (group_1/.../group_n/preset_name)
	>> Search by presets using wildcard (group_1/.../group_n/*)
> Added more tests for the search compiler.