### PR TITLE
Fix WMS GetCapabilities caused by xmlns mismatch

### DIFF
--- a/src/org/openstreetmap/josm/io/imagery/WMSImagery.java
+++ b/src/org/openstreetmap/josm/io/imagery/WMSImagery.java
@@ -346,7 +346,7 @@ public class WMSImagery {
             child = getChild(child, "Get");
             child = getChild(child, "OnlineResource");
             if (child != null) {
-                String baseURL = child.getAttribute("xlink:href");
+                String baseURL = child.getAttributeNS("http://www.w3.org/1999/xlink", "href");
                 if (!baseURL.equals(serviceUrlStr)) {
                     URL newURL = new URL(baseURL);
                     if (newURL.getAuthority() != null) {


### PR DESCRIPTION
Hello @openstreetmap team,

This is a fix for naive namespaced attribute matching to get `href` of `xlink` namespace.

The root cause of this issue is incorrect method used to get namespaced attribute of XML element:

```java
String baseURL = child.getAttribute("xlink:href");
```

Where the proper way for getting namespaced attributes is:

```java
String baseURL = child.getAttributeNS("http://www.w3.org/1999/xlink", "href");
```

Due to above the `baseURL` is empty in case when `http://www.w3.org/1999/xlink` namespace URI is linked to a prefix different than `xlink` (this is what happened to me).

Ho to reproduce the problem? Try to add WMS with the following endpoint:

http://wms.hgis.cartomatic.pl/topo/3857/m25k?service=WMS&request=GetCapabilities

This will return the following XML (only important part is included here, to get full XML just open it in web browser):

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<WMS_Capabilities
  xmlns="http://www.opengis.net/wms"
  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0">
  ...
  <Capability>
    <Request>
      ...
      <GetMap>
        ...
        <DCPType>
          <HTTP>
            <Get>
              <OnlineResource
                xmlns:d8p1="http://www.w3.org/1999/xlink"
                d8p1:href="http://wms.hgis.cartomatic.pl/topo/3857/m25k"
                d8p1:type="simple"/>
            </Get>
          </HTTP>
        </DCPType>
      </GetMap>
    </Request>
  </Capability>
</WMS_Capabilities>
```

In the `OnlineResource` element we can see that `http://www.w3.org/1999/xlink` namespace URI is linked with the `d8p1` prefix, but the code expect it to be `xlink`, which is wrong because namespace URI is really important, not the prefix.

When did this with buggy code I got:

![image](https://user-images.githubusercontent.com/472658/39529890-090a5c62-4e28-11e8-8669-99e62d9dded5.png)

After fixing this problem the WMS capabilities import works like a charm:

![image](https://user-images.githubusercontent.com/472658/39529514-2aed1014-4e27-11e8-97b6-ccafaf37814c.png)

I will create separate bug in your Track so this issue is not missed.

Take care!