### PR TITLE
macosx: register .joz file type handler

### DIFF
--- a/macosx/JOSM.app/Contents/Info.plist_template.xml
+++ b/macosx/JOSM.app/Contents/Info.plist_template.xml
@@ -30,6 +30,28 @@
             <string>application/x-osm+xml</string>
         </dict>
     </dict>
+    <!-- Export JOSM session file format UTI (*.joz) -->
+    <dict>
+        <key>UTTypeIdentifier</key>
+        <string>org.openstreetmap.josm.joz</string>
+        <key>UTTypeDescription</key>
+        <string>JOZ File</string>
+        <key>UTTypeIconFile</key>
+        <string>JOSM.icns</string>
+        <key>UTTypeConformsTo</key>
+        <array>
+            <string>com.pkware.zip-archive</string>
+        </array>
+        <key>UTTypeTagSpecification</key>
+        <dict>
+            <key>com.apple.ostype</key>
+            <string>JOSM</string>
+            <key>public.filename-extension</key>
+            <array>
+                <string>joz</string>
+            </array>
+        </dict>
+    </dict>
 </array>
 <key>UTImportedTypeDeclarations</key>
 <array>
@@ -101,6 +123,21 @@
             <string>com.pkware.zip-archive</string>
             <string>org.gnu.gnu-zip-archive</string>
             <string>public.archive.bzip2</string>
+        </array>
+    </dict>
+    <!-- Registers opening *.joz files -->
+    <dict>
+        <key>CFBundleTypeIconFile</key>
+        <string>JOSM.icns</string>
+        <key>CFBundleTypeName</key>
+        <string>JOZ Files</string>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+        <key>LSHandlerRank</key>
+        <string>Owner</string>
+        <key>LSItemContentTypes</key>
+        <array>
+            <string>org.openstreetmap.josm.joz</string>
         </array>
     </dict>
     <!-- Registers opening *.gpx files -->


### PR DESCRIPTION
Tested manually on Mac OS X 10.13.4 by applying the same changes to Info.plist of JOSM 13878. With the changes the .joz (JOSM sessions) files have JOSM's icon and can be opened by double clicking.