### PR TITLE
MergeLayerActionTest, DownloadWmsAlongTrackActionTest: fix for non-headless mode by properly mocking dialogs

### DIFF
--- a/src/org/openstreetmap/josm/actions/AbstractMergeAction.java
+++ b/src/org/openstreetmap/josm/actions/AbstractMergeAction.java
@@ -109,10 +109,7 @@ public abstract class AbstractMergeAction extends JosmAction {
         JPanel pnl = new JPanel(new GridBagLayout());
         pnl.add(new JLabel(label), GBC.eol());
         pnl.add(layerList, GBC.eol().fill(GBC.HORIZONTAL));
-        if (GraphicsEnvironment.isHeadless()) {
-            // return first layer in headless mode, for unit tests
-            return targetLayers[0];
-        }
+
         ExtendedDialog ed = new ExtendedDialog(MainApplication.getMainFrame(), title, buttonText, tr("Cancel"));
         ed.setButtonIcons(buttonIcon, "cancel");
         ed.setContent(pnl);
@@ -130,8 +127,6 @@ public abstract class AbstractMergeAction extends JosmAction {
     protected void warnNoTargetLayersForSourceLayer(Layer sourceLayer) {
         String message = tr("<html>There are no layers the source layer<br>''{0}''<br>could be merged to.</html>",
                 Utils.escapeReservedCharactersHTML(sourceLayer.getName()));
-        if (!GraphicsEnvironment.isHeadless()) {
-            JOptionPane.showMessageDialog(MainApplication.getMainFrame(), message, tr("No target layers"), JOptionPane.WARNING_MESSAGE);
-        }
+        JOptionPane.showMessageDialog(MainApplication.getMainFrame(), message, tr("No target layers"), JOptionPane.WARNING_MESSAGE);
     }
 }

--- a/src/org/openstreetmap/josm/gui/layer/gpx/DownloadWmsAlongTrackAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/gpx/DownloadWmsAlongTrackAction.java
@@ -117,9 +117,7 @@ public class DownloadWmsAlongTrackAction extends AbstractAction {
     protected AbstractTileSourceLayer<? extends AbstractTMSTileSource> askedLayer() {
         List<AbstractTileSourceLayer> targetLayers = MainApplication.getLayerManager().getLayersOfType(AbstractTileSourceLayer.class);
         if (targetLayers.isEmpty()) {
-            if (!GraphicsEnvironment.isHeadless()) {
-                warnNoImageryLayers();
-            }
+            warnNoImageryLayers();
             return null;
         }
         return AbstractMergeAction.askTargetLayer(targetLayers.toArray(new AbstractTileSourceLayer[0]),

--- a/test/unit/org/openstreetmap/josm/actions/MergeLayerActionTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/MergeLayerActionTest.java
@@ -1,6 +1,9 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.actions;
 
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -8,10 +11,17 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.LayerManagerTest.TestLayer;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.gui.widgets.JosmComboBox;
+import org.openstreetmap.josm.TestUtils;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
+import org.openstreetmap.josm.testutils.mockers.ExtendedDialogMocker;
+import org.openstreetmap.josm.testutils.mockers.JOptionPaneSimpleMocker;
+
+import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -26,6 +36,18 @@ public class MergeLayerActionTest {
     @Rule
     @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public JOSMTestRules test = new JOSMTestRules().main();
+
+    public static class MergeLayerExtendedDialogMocker extends ExtendedDialogMocker {
+        @Override
+        protected void act(final ExtendedDialog instance) {
+            ((JosmComboBox) ((JPanel) this.getContent(instance)).getComponent(1)).setSelectedIndex(0);
+        }
+
+        @Override
+        protected String getString(final ExtendedDialog instance) {
+            return ((JLabel) ((JPanel) this.getContent(instance)).getComponent(0)).getText();
+        }
+    };
 
     private MergeLayerAction action;
 
@@ -57,11 +79,21 @@ public class MergeLayerActionTest {
      */
     @Test
     public void testMergeNoTargetLayer() {
-        OsmDataLayer layer = new OsmDataLayer(new DataSet(), "", null);
+        TestUtils.assumeWorkingJMockit();
+        final JOptionPaneSimpleMocker jopsMocker = new JOptionPaneSimpleMocker(
+            ImmutableMap.<String, Object>of("<html>There are no layers the source layer<br>'onion'<br>could be merged to.</html>", 0)
+        );
+
+        OsmDataLayer layer = new OsmDataLayer(new DataSet(), "onion", null);
         MainApplication.getLayerManager().addLayer(layer);
         assertEquals(1, MainApplication.getLayerManager().getLayers().size());
         assertNull(action.merge(layer));
         assertEquals(1, MainApplication.getLayerManager().getLayers().size());
+
+        assertEquals(1, jopsMocker.getInvocationLog().size());
+        Object[] invocationLogEntry = jopsMocker.getInvocationLog().get(0);
+        assertEquals(0, (int) invocationLogEntry[0]);
+        assertEquals("No target layers", invocationLogEntry[2]);
     }
 
     /**
@@ -70,6 +102,10 @@ public class MergeLayerActionTest {
      */
     @Test
     public void testMergeTwoEmptyLayers() throws Exception {
+        TestUtils.assumeWorkingJMockit();
+        final MergeLayerExtendedDialogMocker edMocker = new MergeLayerExtendedDialogMocker();
+        edMocker.getMockResultMap().put("Please select the target layer.", "Merge");
+
         OsmDataLayer layer1 = new OsmDataLayer(new DataSet(), "1", null);
         OsmDataLayer layer2 = new OsmDataLayer(new DataSet(), "2", null);
         MainApplication.getLayerManager().addLayer(layer1);
@@ -77,5 +113,10 @@ public class MergeLayerActionTest {
         assertEquals(2, MainApplication.getLayerManager().getLayers().size());
         action.merge(layer2).get();
         assertEquals(1, MainApplication.getLayerManager().getLayers().size());
+
+        assertEquals(1, edMocker.getInvocationLog().size());
+        Object[] invocationLogEntry = edMocker.getInvocationLog().get(0);
+        assertEquals(1, (int) invocationLogEntry[0]);
+        assertEquals("Select target layer", invocationLogEntry[2]);
     }
 }

--- a/test/unit/org/openstreetmap/josm/testutils/mockers/ExtendedDialogMocker.java
+++ b/test/unit/org/openstreetmap/josm/testutils/mockers/ExtendedDialogMocker.java
@@ -107,6 +107,13 @@ public class ExtendedDialogMocker extends BaseDialogMockUp<ExtendedDialog> {
         );
     }
 
+    /**
+     * Target for overriding, similar to {@link #getMockResult} except with the implication it will only
+     * be invoked once per dialog display, therefore ideal opportunity to perform any mutating actions,
+     * e.g. making a selection on a widget.
+     */
+    protected void act(final ExtendedDialog instance) {};
+
     protected Object[] getInvocationLogEntry(final ExtendedDialog instance, final int mockResult) {
         return new Object[] {
             mockResult,
@@ -129,6 +136,7 @@ public class ExtendedDialogMocker extends BaseDialogMockUp<ExtendedDialog> {
         if (value == true) {
             try {
                 final ExtendedDialog instance = invocation.getInvokedInstance();
+                this.act(instance);
                 final int mockResult = this.getMockResult(instance);
                 // TODO check validity of mockResult?
                 Deencapsulation.setField(instance, "result", mockResult);

--- a/test/unit/org/openstreetmap/josm/testutils/mockers/ExtendedDialogMocker.java
+++ b/test/unit/org/openstreetmap/josm/testutils/mockers/ExtendedDialogMocker.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.WeakHashMap;
 
+import org.openstreetmap.josm.TestUtils;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.tools.Logging;
 
@@ -120,6 +121,17 @@ public class ExtendedDialogMocker extends BaseDialogMockUp<ExtendedDialog> {
             this.getString(instance),
             instance.getTitle()
         };
+    }
+
+    /**
+     * A convenience method to access {@link ExtendedDialog#content} without exception-catching boilerplate
+     */
+    protected Component getContent(final ExtendedDialog instance) {
+        try {
+            return (Component) TestUtils.getPrivateField(instance, "content");
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Mock

--- a/test/unit/org/openstreetmap/josm/testutils/mockers/HelpAwareOptionPaneMocker.java
+++ b/test/unit/org/openstreetmap/josm/testutils/mockers/HelpAwareOptionPaneMocker.java
@@ -77,6 +77,13 @@ public class HelpAwareOptionPaneMocker extends BaseDialogMockUp<HelpAwareOptionP
         return this.getMockResultMap().get(messageString);
     }
 
+    /**
+     * Target for overriding, similar to {@link #getMockResultForMessage} except with the implication it
+     * will only be invoked once per dialog display, therefore ideal opportunity to perform any mutating
+     * actions, e.g. making a selection on a widget.
+     */
+    protected void act(final Object message) {};
+
     protected int getButtonPositionFromLabel(
         final HelpAwareOptionPane.ButtonSpec[] options,
         final String label
@@ -133,6 +140,7 @@ public class HelpAwareOptionPaneMocker extends BaseDialogMockUp<HelpAwareOptionP
         final String helpTopic
     ) {
         try {
+            this.act(msg);
             final Object result = this.getMockResultForMessage(msg);
 
             if (result == null) {

--- a/test/unit/org/openstreetmap/josm/testutils/mockers/JOptionPaneSimpleMocker.java
+++ b/test/unit/org/openstreetmap/josm/testutils/mockers/JOptionPaneSimpleMocker.java
@@ -133,6 +133,13 @@ public class JOptionPaneSimpleMocker extends BaseDialogMockUp<JOptionPane> {
         return this.getMockResultMap().get(messageString);
     }
 
+    /**
+     * Target for overriding, similar to {@link #getMockResultForMessage} except with the implication it
+     * will only be invoked once per dialog display, therefore ideal opportunity to perform any mutating
+     * actions, e.g. making a selection on a widget.
+     */
+    protected void act(final Object message) {};
+
     protected Object[] getInvocationLogEntry(
         final Object message,
         final String title,
@@ -161,6 +168,7 @@ public class JOptionPaneSimpleMocker extends BaseDialogMockUp<JOptionPane> {
         final Object initialSelectionValue
     ) {
         try {
+            this.act(message);
             final Object result = this.getMockResultForMessage(message);
             if (selectionValues == null) {
                 if (!(result instanceof String)) {
@@ -215,6 +223,7 @@ public class JOptionPaneSimpleMocker extends BaseDialogMockUp<JOptionPane> {
         final Icon icon
     ) {
         try {
+            this.act(message);
             // why look up a "result" for a message dialog which can only have one possible result? it's
             // a good opportunity to assert its contents
             final Object result = this.getMockResultForMessage(message);
@@ -262,6 +271,7 @@ public class JOptionPaneSimpleMocker extends BaseDialogMockUp<JOptionPane> {
         final Icon icon
     ) {
         try {
+            this.act(message);
             final Object result = this.getMockResultForMessage(message);
             if (!(result instanceof Integer && Ints.contains(optionTypePermittedResults.get(optionType), (int) result))) {
                 fail(String.format(


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/16841