### PR TITLE
Fix relation ordering after split-way

### DIFF
--- a/src/org/openstreetmap/josm/data/osm/DefaultNameFormatter.java
+++ b/src/org/openstreetmap/josm/data/osm/DefaultNameFormatter.java
@@ -478,7 +478,15 @@ public class DefaultNameFormatter implements NameFormatter, HistoryNameFormatter
         }
     }
 
-    private static String getRelationName(IRelation<?> relation) {
+    /**
+     * Get the name for a relation by looking at a number of name-like tags (starting with {@code name} and {@code
+     * ref}). If the user has configured JOSM to display names in a localized language, the appropriate language tags
+     * are taken into consideration as well.
+     *
+     * @param relation Relation to find the name for.
+     * @return Relation name. This may be {@code null}.
+     */
+    public static String getRelationName(IRelation<?> relation) {
         String nameTag;
         for (String n : getNamingtagsForRelations()) {
             nameTag = getNameTagValue(relation, n);

--- a/src/org/openstreetmap/josm/gui/MainApplication.java
+++ b/src/org/openstreetmap/josm/gui/MainApplication.java
@@ -1043,7 +1043,11 @@ public class MainApplication {
         AbstractCredentialsAgent.setCredentialsProvider(CredentialDialog::promptCredentials);
         MessageNotifier.setNotifierCallback(MainApplication::notifyNewMessages);
         DeleteCommand.setDeletionCallback(DeleteAction.defaultDeletionCallback);
-        SplitWayCommand.setWarningNotifier(msg -> new Notification(msg).setIcon(JOptionPane.WARNING_MESSAGE).show());
+        SplitWayCommand.setWarningNotifier(msg -> new Notification(msg)
+                .setIcon(JOptionPane.WARNING_MESSAGE)
+                // Split-way warnings may contain references to multiple relations which may take a while to read.
+                .setDuration(Notification.TIME_VERY_LONG)
+                .show());
         FileWatcher.registerLoader(SourceType.MAP_PAINT_STYLE, MapPaintStyleLoader::reloadStyle);
         FileWatcher.registerLoader(SourceType.TAGCHECKER_RULE, MapCSSTagChecker::reloadRule);
         OsmUrlToBounds.setMapSizeSupplier(() -> {


### PR DESCRIPTION
In some cases the split-way command failed to detect the direction of ways part of a relation by breaking too soon from the loop that inspects relation members. This commit fixes this.

Additionally, a warning is shown to the user if by splitting the way a relation may have been damaged. This warning is raised when all of these requirements are met:

* the relation concerned is a route or multipolygon,
* has more than one member,
* does not have all of its members downloaded, and
* the direction could not be determined from the available members.

## Background

This bug causes routes for public transport, hiking, and cycling to break when edits are performed on small parts of the map — e.g., when a mapper is working on details in a neighbourhood. It is common for such relations to have only a few members downloaded.

The split way command tries to determine the order of the new parts by looking at the available members, but due to a bug in the detection loop this can fail even when at least two connected members are available. This specific bug is hit when a way is split that is at one end of the downloaded members: in that case there is a 50% chance (depending on the position of the member in the relation) that the split will place the new parts in the wrong order. This commit solves this by not breaking from the detection loop too soon.