### PR TITLE
ant: Allow running a subset of tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -486,6 +486,12 @@ Build-Date: ${build.tstamp}
             </junitlauncher>
         </sequential>
     </macrodef>
+    <target name="test-subset" depends="test-compile" unless="test.notRequired"
+        description="Run single test class, as specified on commandline">
+        <fail message="No test family selected. Run with e.g. -Dtestfamily=unit" unless="testfamily"/>
+        <fail message="No test classes selected. Run with e.g. -Dtestclasses='**/MyTest.class'" unless="testclasses"/>
+        <call-junit testfamily="${testfamily}" includes="${testclasses}"/>
+    </target>
     <target name="test" depends="test-compile" unless="test.notRequired"
         description="Run unit and functional tests. OSM API (TEST) account shall be set with -Dosm.username and -Dosm.password">
         <call-junit testfamily="unit"/>


### PR DESCRIPTION
This exposes a `test-subset` target that can be used to run a subset of
tests. For example, to run a single test, specify the family and the
path to the class file (relative to the family directory):

    ant test-subset -Dtestfamily=unit -Dtestclasses="org/openstreetmap/josm/gui/dialogs/relation/sort/WayConnectionTypeCalculatorTest.class"

The `testclasses` parameter is interpreted as a pattern, so it is
usually easier to just specify the classname rather than the full path:

    ant test-subset -Dtestfamily=unit -Dtestclasses="**/WayConnectionTypeCalculatorTest.class"

Alternatively, you can run all tests from a particular directory:

    ant test-subset -Dtestfamily=unit -Dtestclasses="org/openstreetmap/josm/gui/dialogs/relation/sort/*Test.class"

Or recursively:

    ant test-subset -Dtestfamily=unit -Dtestclasses="org/openstreetmap/josm/gui/dialogs/**/*Test.class"

The console output generated by this is not ideal (A separate summary
for each test class, without including the testclass name, no overall
summary), more useful output per test can be found in the `test/report`
directory afterwards.

Ideally, more detailed info about (failing) tests would be printed to
the console directory, but it seems that ant-junitlauncher has no
builtin way to log test output to the console (junit has a
LoggerListener, but it is not directly instantiatable), so this probably
requires a custom `TestExecutionListener` class (see
https://www.selikoff.net/2018/07/28/ant-and-junit-5-outputting-test-duration-and-failure-to-the-log/
for a starting point).