### PR TITLE
Improvements to macOS build and github actions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -120,8 +120,14 @@ jobs:
           defaults write net.pornel.ImageOptim PngOutEnabled 1
           /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build with Ant
+        # Disables errorprone for Java 16
+        # See https://github.com/google/error-prone/issues/1872
         run: |
-          ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+          if [[ "x${{ matrix.java }}x" =~ x1[6-9](-ea)?x ]]; then
+            ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+          else
+            ${{ env.ANT_HOME }}/bin/ant dist
+          fi
       - name: Upload jar
         if: ${{ always() && matrix.headless }}
         id: upload-jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
-    strategy:
-      fail-fast: false
+    outputs: 
+      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,8 +42,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
@@ -91,8 +91,6 @@ jobs:
             os: macos-latest
           - java: 11
             os: macos-latest
-          - java: 16-ea
-            os: macos-latest
           - headless: "false"
             os: macos-latest
           - headless: "false"
@@ -120,8 +118,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
@@ -169,7 +167,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 64
+          fetch-depth: 128
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -59,8 +59,8 @@ jobs:
         id: create_revision
         run: |
           ant create-revision
-          josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
-          if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
+          josm_revision="$(awk '/Revision/{print $2}' resources/REVISION)"
+          if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::false"

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,7 +31,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -39,13 +39,14 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar zxvf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
@@ -108,7 +109,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -116,13 +117,15 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cp -a ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Build with Ant, headless ${{ matrix.headless }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,12 +20,12 @@ jobs:
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 32
+          fetch-depth: 64
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -66,6 +66,7 @@ jobs:
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
+          echo "::set-output name=josm_revision::$josm_revision"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -147,7 +148,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: Ant reports for JOSM ${{ env.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
+          name: Ant reports for JOSM ${{ needs.createrelease.outputs.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
           path: test/report/*.txt
       - name: Optimise images
         if: ${{ runner.os == 'macos' && always() }}
@@ -165,7 +166,7 @@ jobs:
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
           $ANT_HOME/bin/ant -DnoErrorProne dist
-          ./native/macosx/macos-jpackage.sh ${{ env.josm_revision }}
+          ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
         id: upload-app
@@ -186,5 +187,5 @@ jobs:
         with:
           upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -67,7 +67,7 @@ jobs:
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
-            echo "::set-output name=josm_prerelease::true
+            echo "::set-output name=josm_prerelease::true"
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -21,6 +21,8 @@ jobs:
       LANG: en_US.UTF-8
     outputs: 
       upload_url: ${{ steps.create_release.outputs.upload_url }}
+      josm_revision: ${{ steps.create_revision.outputs.josm_revision }}
+      josm_prerelease: ${{ steps.create_revision.outputs.josm_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,6 +56,7 @@ jobs:
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
+        id: create_revision
         run: |
           ant create-revision
           josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
@@ -67,6 +70,7 @@ jobs:
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
+          echo "::set-output name=josm_prerelease::$josm_prerelease"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -133,7 +137,11 @@ jobs:
           cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Build with Ant
+        run: |
+          ${{ env.ANT_HOME }}/bin/ant dist
       - name: Build with Ant, headless ${{ matrix.headless }}
+        if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
           if [ "${{ matrix.headless }}" == "true" ]; then

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 32
       - name: Set revision env variable
         id: create_revision
-        # revision gets grabbed from last git-svn-id
+        # grab josm revision from last git-svn-id
         run: |
           josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -39,11 +39,12 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
+            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          fi
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -44,8 +44,8 @@ jobs:
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~
-          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          tar zxvf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 128
+          fetch-depth: 32
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -39,7 +39,8 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: '15'
+          # We just run ant create-revision in this job. Using Java 11 LTS.
+          java-version: '11'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
           mkdir -p build-tools-cache/

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -28,39 +28,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 32
-      - name: Cache
-        uses: actions/cache@v2.0.0
-        with:
-          path:  |
-            ~/.ivy2/cache/
-            ~/work/josm/josm/tools/
-            build-tools-cache/
-          key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
-      - name: Setup java
-        uses: actions/setup-java@v1.4.3
-        with:
-          # We just run ant create-revision in this job. Using Java 11 LTS.
-          java-version: '11'
-      - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
-        run: |
-          mkdir -p build-tools-cache/
-          cd build-tools-cache/
-          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
-            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          fi
-          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          fi
-          cd ..
-          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-      - name: Print ant version, expecting ${{ env.ANT_HOME }}
-        run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
         id: create_revision
+        # revision gets grabbed from last git-svn-id
         run: |
-          ant create-revision
-          josm_revision="$(awk '/Revision/{print $2}' resources/REVISION)"
+          josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -63,14 +63,15 @@ jobs:
           if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::false"
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::true
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
-          echo "::set-output name=josm_prerelease::$josm_prerelease"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -137,10 +138,29 @@ jobs:
           cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Optimise images
+        if: ${{ runner.os == 'macos' && always() }}
+        run: |
+          brew cask install imageoptim
+          defaults write net.pornel.ImageOptim SvgoEnabled 1
+          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
+          defaults write net.pornel.ImageOptim PngOutEnabled 1
+          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build with Ant
         run: |
-          ${{ env.ANT_HOME }}/bin/ant dist
-      - name: Build with Ant, headless ${{ matrix.headless }}
+          ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+      - name: Upload jar
+        if: ${{ always() && matrix.headless }}
+        id: upload-jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
+          asset_path: dist/josm-custom.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+          asset_content_type: application/java-archive
+      - name: Test with Ant, headless ${{ matrix.headless }}
         if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
@@ -158,14 +178,6 @@ jobs:
         with:
           name: Ant reports for JOSM ${{ needs.createrelease.outputs.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
           path: test/report/*.txt
-      - name: Optimise images
-        if: ${{ runner.os == 'macos' && always() }}
-        run: |
-          brew cask install imageoptim
-          defaults write net.pornel.ImageOptim SvgoEnabled 1
-          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
-          defaults write net.pornel.ImageOptim PngOutEnabled 1
-          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build and package for macOS
         if: ${{ runner.os == 'macos' && always() }}
         env:
@@ -173,7 +185,6 @@ jobs:
           CERT_MACOS_PW: ${{ secrets.CERT_MACOS_PW }}
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
-          $ANT_HOME/bin/ant -DnoErrorProne dist
           ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
@@ -186,14 +197,3 @@ jobs:
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip
-      - name: Upload jar
-        if: ${{ always() }}
-        id: upload-jar
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-          asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -58,7 +58,7 @@ jobs:
           ant create-revision
           josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
           if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
-            sed -i .bak '/Is-Local-Build/d' resources/REVISION
+            sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,7 +31,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/work/josm/josm/build-tools-cache/
+            build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -39,15 +39,17 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/work/josm/josm/build-tools-cache/
-          cd ~/work/josm/josm/build-tools-cache/
+          mkdir -p build-tools-cache/
+          cd build-tools-cache/
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          fi
+          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
             curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
-          cd ~/work/josm/josm/
-          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ..
+          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
@@ -108,7 +110,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/work/josm/josm/build-tools-cache/
+            build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -116,17 +118,17 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          pwd
-          mkdir -p ~/work/josm/josm/build-tools-cache/
-          cd ~/work/josm/josm/build-tools-cache/
+          mkdir -p build-tools-cache/
+          cd build-tools-cache/
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          fi
+          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
             curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
-          cd ~/work/josm/josm/
-          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cp -a ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ..
+          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Build with Ant, headless ${{ matrix.headless }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -14,7 +14,67 @@ defaults:
     shell: bash
 
 jobs:
+  createrelease:
+    runs-on: ubuntu-latest
+    env:
+      LANG: en_US.UTF-8
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 32
+      - name: Cache
+        uses: actions/cache@v2.0.0
+        with:
+          path:  |
+            ~/.ivy2/cache/
+            ~/work/josm/josm/tools/
+            ~/build-tools-cache/
+          key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
+      - name: Setup java
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
+        run: |
+          mkdir -p ~/build-tools-cache/
+          cd ~/build-tools-cache/
+          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~
+          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+      - name: Print ant version, expecting ${{ env.ANT_HOME }}
+        run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Set revision env variable
+        run: |
+          ant create-revision
+          josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
+          if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
+            sed -i .bak '/Is-Local-Build/d' resources/REVISION
+            echo "josm_prerelease=false" >> $GITHUB_ENV
+            echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
+          else
+            echo "josm_prerelease=true" >> $GITHUB_ENV
+            echo "josm_release=$josm_revision" >> $GITHUB_ENV
+          fi
+          echo "josm_revision=$josm_revision" >> $GITHUB_ENV
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.josm_release }}
+          release_name: JOSM.app release ${{ env.josm_release }}
+          body: |
+            JOSM.app release ${{ env.josm_release }}
+          draft: false
+          prerelease: ${{ env.josm_prerelease }}
   build:
+    needs: createrelease
     runs-on: ${{ matrix.os }}
     env:
       LANG: en_US.UTF-8
@@ -41,36 +101,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 128
+          fetch-depth: 32
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
+            ~/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
         with:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
-        # Todo: cache ant and junit, saves 12 seconds.
         run: |
-          curl -s https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz | tar -xz
-          curl -o ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar  "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar"
+          mkdir -p ~/build-tools-cache/
+          cd ~/build-tools-cache/
+          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~
+          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
-      - name: Set revision env variable
-        run: |
-          ant create-revision
-          josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
-          if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
-            sed -i .bak '/Is-Local-Build/d' resources/REVISION
-            echo "josm_prerelease=false" >> $GITHUB_ENV
-          else
-            echo "josm_prerelease=true" >> $GITHUB_ENV
-          fi
-          echo "josm_revision=$josm_revision" >> $GITHUB_ENV
       - name: Build with Ant, headless ${{ matrix.headless }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
@@ -105,19 +159,6 @@ jobs:
         run: |
           $ANT_HOME/bin/ant -DnoErrorProne dist
           ./native/macosx/macos-jpackage.sh ${{ env.josm_revision }}
-      - name: Create macOS release
-        if: ${{ runner.os == 'macos' && always() }}
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ env.josm_revision }}
-          release_name: JOSM.app release ${{ env.josm_revision }}
-          body: |
-            JOSM.app release ${{ env.josm_revision }}
-          draft: false
-          prerelease: ${{ env.josm_prerelease }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
         id: upload-app
@@ -130,7 +171,7 @@ jobs:
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip
       - name: Upload jar
-        if: ${{ runner.os == 'macos' && always() }}
+        if: ${{ always() }}
         id: upload-jar
         uses: actions/upload-release-asset@v1
         env:
@@ -138,5 +179,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: dist/josm-custom.jar
-          asset_name: josm-latest.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -119,8 +119,10 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
+            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          fi
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
           mkdir -p ~/build-tools-cache/

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,11 +15,12 @@ defaults:
 
 jobs:
   createrelease:
+    name: Create Release
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,8 +45,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -123,8 +124,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -183,7 +184,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -81,7 +81,7 @@ echo "Signing App Bundle…"
 #     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
 #     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
 
-# codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app
+codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app/Contents/app/josm-custom.jar
 
 # codesign -vvv app/JOSM.app
 

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -17,23 +17,6 @@ fi
 echo "Building JOSM.app"
 
 mkdir app
-jpackage -n "JOSM" --input dist --main-jar josm-custom.jar \
-    --main-class org.openstreetmap.josm.gui.MainApplication \
-    --icon ./native/macosx/JOSM.icns --type app-image --dest app \
-    --java-options "-Xmx8192m" --app-version $1 \
-    --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
-    --vendor "https://josm.openstreetmap.de" \
-    --file-associations native/macosx/bz2.properties \
-    --file-associations native/macosx/geojson.properties \
-    --file-associations native/macosx/gpx.properties \
-    --file-associations native/macosx/gz.properties \
-    --file-associations native/macosx/jos.properties \
-    --file-associations native/macosx/joz.properties \
-    --file-associations native/macosx/osm.properties \
-    --file-associations native/macosx/zip.properties \
-    --add-modules java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.sql,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.jfr,jdk.jsobject,jdk.unsupported,jdk.unsupported.desktop,jdk.xml.dom
-
-echo "Building done."
 
 if [[ $IMPORT_AND_UNLOCK_KEYCHAIN == 1 ]]; then
     if [ -z "$CERT_MACOS_P12" ]
@@ -66,17 +49,40 @@ if [[ $IMPORT_AND_UNLOCK_KEYCHAIN == 1 ]]; then
     echo "Signing preparation done."
 fi
 
+echo "Building and signin app"
+    jpackage -n "JOSM" --input dist --main-jar josm-custom.jar \
+    --main-class org.openstreetmap.josm.gui.MainApplication \
+    --icon ./native/macosx/JOSM.icns --type app-image --dest app \
+    --java-options "-Xmx8192m" --app-version $1 \
+    --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
+    --vendor "https://josm.openstreetmap.de" \
+    --mac-sign \
+    --mac-package-identifier de.openstreetmap.josm \
+    --mac-package-signing-prefix de.openstreetmap.josm \
+    --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
+    --file-associations native/macosx/bz2.properties \
+    --file-associations native/macosx/geojson.properties \
+    --file-associations native/macosx/gpx.properties \
+    --file-associations native/macosx/gz.properties \
+    --file-associations native/macosx/jos.properties \
+    --file-associations native/macosx/joz.properties \
+    --file-associations native/macosx/osm.properties \
+    --file-associations native/macosx/zip.properties \
+    --add-modules java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.sql,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.jfr,jdk.jsobject,jdk.unsupported,jdk.unsupported.desktop,jdk.xml.dom
+
+echo "Building done."
+
 echo "Signing App Bundle…"
 
-codesign -vvv --timestamp --options runtime --deep --force --sign "$SIGNING_KEY_NAME" \
-    app/JOSM.app/Contents/MacOS/JOSM \
-    app/JOSM.app/Contents/runtime/Contents/Home/lib/*.jar \
-    app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
-    app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
+# codesign -vvv --timestamp --options runtime --deep --force --sign "$SIGNING_KEY_NAME" \
+#     app/JOSM.app/Contents/MacOS/JOSM \
+#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.jar \
+#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
+#     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
 
-codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app
+# codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app
 
-codesign -vvv app/JOSM.app
+# codesign -vvv app/JOSM.app
 
 echo "Preparing for notarization"
 ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -54,7 +54,9 @@ echo "Building and signin app"
     jpackage -n "JOSM" --input dist --main-jar josm-custom.jar \
     --main-class org.openstreetmap.josm.gui.MainApplication \
     --icon ./native/macosx/JOSM.icns --type app-image --dest app \
-    --java-options "-Xmx8192m" --app-version $1 \
+    --java-options "-Xmx8192m" \
+     --java-options "-Dapple.awt.application.appearance=system" \
+    --app-version $1 \
     --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
     --vendor "https://josm.openstreetmap.de" \
     --mac-sign \
@@ -72,18 +74,6 @@ echo "Building and signin app"
     --add-modules java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.sql,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.jfr,jdk.jsobject,jdk.unsupported,jdk.unsupported.desktop,jdk.xml.dom
 
 echo "Building done."
-
-echo "Signing App Bundle…"
-
-# codesign -vvv --timestamp --options runtime --deep --force --sign "$SIGNING_KEY_NAME" \
-#     app/JOSM.app/Contents/MacOS/JOSM \
-#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.jar \
-#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
-#     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
-
-codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app/Contents/app/josm-custom.jar
-
-# codesign -vvv app/JOSM.app
 
 echo "Preparing for notarization"
 ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -60,6 +60,7 @@ echo "Building and signin app"
     --mac-package-identifier de.openstreetmap.josm \
     --mac-package-signing-prefix de.openstreetmap.josm \
     --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
+    --mac-signing-keychain $KEYCHAIN \
     --file-associations native/macosx/bz2.properties \
     --file-associations native/macosx/geojson.properties \
     --file-associations native/macosx/gpx.properties \

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -35,6 +35,7 @@ if [[ $IMPORT_AND_UNLOCK_KEYCHAIN == 1 ]]; then
     echo "Preparing certificates/keychain for signing…"
 
     KEYCHAIN=build.keychain
+    KEYCHAINPATH=~/Library/Keychains/$KEYCHAIN-db
     KEYCHAIN_PW=`head /dev/urandom | base64 | head -c 20`
     CERTIFICATE_P12=certificate.p12
 
@@ -59,8 +60,7 @@ echo "Building and signin app"
     --mac-sign \
     --mac-package-identifier de.openstreetmap.josm \
     --mac-package-signing-prefix de.openstreetmap.josm \
-    --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
-    --mac-signing-keychain $KEYCHAIN \
+    --mac-signing-keychain $KEYCHAINPATH \
     --file-associations native/macosx/bz2.properties \
     --file-associations native/macosx/geojson.properties \
     --file-associations native/macosx/gpx.properties \


### PR DESCRIPTION
This does a few things:

- Separate the create-release github action to pass the release url to all subsequent jobs, to be able to...
- Upload .jar artefacts from all runs, and a separate .app for all java versions for macOS
- Better caching for ant/junit
- Support for the release workflow from https://josm.openstreetmap.de/ticket/20146
- A few cosmetic fixes, more readable syntax, etc.