### PR TITLE
Improve macOS build

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -120,8 +120,14 @@ jobs:
           defaults write net.pornel.ImageOptim PngOutEnabled 1
           /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build with Ant
+        # Disables errorprone for Java 16
+        # See https://github.com/google/error-prone/issues/1872
         run: |
-          ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+          if [[ "x${{ matrix.java }}x" =~ x1[6-9](-ea)?x ]]; then
+            ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+          else
+            ${{ env.ANT_HOME }}/bin/ant dist
+          fi
       - name: Upload jar
         if: ${{ always() && matrix.headless }}
         id: upload-jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
-    strategy:
-      fail-fast: false
+    outputs: 
+      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,8 +42,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
@@ -91,8 +91,6 @@ jobs:
             os: macos-latest
           - java: 11
             os: macos-latest
-          - java: 16-ea
-            os: macos-latest
           - headless: "false"
             os: macos-latest
           - headless: "false"
@@ -120,8 +118,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
@@ -169,7 +167,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 64
+          fetch-depth: 128
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -59,8 +59,8 @@ jobs:
         id: create_revision
         run: |
           ant create-revision
-          josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
-          if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
+          josm_revision="$(awk '/Revision/{print $2}' resources/REVISION)"
+          if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::false"

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -144,7 +144,7 @@ jobs:
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
           asset_content_type: application/java-archive
       - name: Test with Ant, headless ${{ matrix.headless }}
-        if: ${{ needs.createrelease.outputs.josm_prerelease }}
+        if: ${{ env.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
           if [ "${{ matrix.headless }}" == "true" ]; then
@@ -161,6 +161,16 @@ jobs:
         with:
           name: Ant reports for JOSM ${{ needs.createrelease.outputs.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
           path: test/report/*.txt
+      - name: Publish Test Report with junit-report-annotations-action
+        uses: ashley-taylor/junit-report-annotations-action@1.3
+        if: always()
+        with:
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Test Report with action-junit-report
+        uses: mikepenz/action-junit-report@v1
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and package for macOS
         if: ${{ runner.os == 'macos' && always() }}
         env:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -166,7 +166,7 @@ jobs:
         if: always()
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
-          path: paths: 'test/report/TEST*.xml'
+          path: 'test/report/TEST*.xml'
       - name: Publish Test Report with action-junit-report
         if: always()
         uses: mikepenz/action-junit-report@v1

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,7 +31,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -39,13 +39,14 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar zxvf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
@@ -106,7 +107,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -114,13 +115,15 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cp -a ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Build with Ant, headless ${{ matrix.headless }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,7 +31,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -39,13 +39,14 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar zxvf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
@@ -108,7 +109,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/build-tools-cache/
+            ~/work/josm/josm/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -116,13 +117,15 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/build-tools-cache/
-          cd ~/build-tools-cache/
+          pwd
+          mkdir -p ~/work/josm/josm/build-tools-cache/
+          cd ~/work/josm/josm/build-tools-cache/
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cd ~
-          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~/work/josm/josm/
+          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cp -a ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Build with Ant, headless ${{ matrix.headless }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,12 +20,12 @@ jobs:
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 32
+          fetch-depth: 64
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -66,6 +66,7 @@ jobs:
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
+          echo "::set-output name=josm_revision::$josm_revision"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -147,7 +148,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: Ant reports for JOSM ${{ env.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
+          name: Ant reports for JOSM ${{ needs.createrelease.outputs.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
           path: test/report/*.txt
       - name: Optimise images
         if: ${{ runner.os == 'macos' && always() }}
@@ -165,7 +166,7 @@ jobs:
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
           $ANT_HOME/bin/ant -DnoErrorProne dist
-          ./native/macosx/macos-jpackage.sh ${{ env.josm_revision }}
+          ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
         id: upload-app
@@ -186,5 +187,5 @@ jobs:
         with:
           upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -67,7 +67,7 @@ jobs:
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
-            echo "::set-output name=josm_prerelease::true
+            echo "::set-output name=josm_prerelease::true"
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -21,6 +21,8 @@ jobs:
       LANG: en_US.UTF-8
     outputs: 
       upload_url: ${{ steps.create_release.outputs.upload_url }}
+      josm_revision: ${{ steps.create_revision.outputs.josm_revision }}
+      josm_prerelease: ${{ steps.create_revision.outputs.josm_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,6 +56,7 @@ jobs:
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
+        id: create_revision
         run: |
           ant create-revision
           josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
@@ -67,6 +70,7 @@ jobs:
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
+          echo "::set-output name=josm_prerelease::$josm_prerelease"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -133,7 +137,11 @@ jobs:
           cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Build with Ant
+        run: |
+          ${{ env.ANT_HOME }}/bin/ant dist
       - name: Build with Ant, headless ${{ matrix.headless }}
+        if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
           if [ "${{ matrix.headless }}" == "true" ]; then

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 32
       - name: Set revision env variable
         id: create_revision
-        # revision gets grabbed from last git-svn-id
+        # grab josm revision from last git-svn-id
         run: |
           josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -122,7 +122,7 @@ jobs:
         if: ${{ ! env.josm_prerelease }}
         run: |
           ant create-revision
-          sed -i '/Is-Local-Build/d' resources/REVISION
+          sed -i.bak '/Is-Local-Build/d' resources/REVISION
       - name: Build with Ant
         # Disables errorprone for Java 16
         # See https://github.com/google/error-prone/issues/1872

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 64
       - name: Cache
         uses: actions/cache@v2.0.0
         with:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -39,11 +39,12 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
+            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          fi
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -44,8 +44,8 @@ jobs:
           wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~
-          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          tar zxvf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 128
+          fetch-depth: 32
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -39,7 +39,8 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: '15'
+          # We just run ant create-revision in this job. Using Java 11 LTS.
+          java-version: '11'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
           mkdir -p build-tools-cache/

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -28,39 +28,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 32
-      - name: Cache
-        uses: actions/cache@v2.0.0
-        with:
-          path:  |
-            ~/.ivy2/cache/
-            ~/work/josm/josm/tools/
-            build-tools-cache/
-          key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
-      - name: Setup java
-        uses: actions/setup-java@v1.4.3
-        with:
-          # We just run ant create-revision in this job. Using Java 11 LTS.
-          java-version: '11'
-      - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
-        run: |
-          mkdir -p build-tools-cache/
-          cd build-tools-cache/
-          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
-            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          fi
-          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          fi
-          cd ..
-          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-      - name: Print ant version, expecting ${{ env.ANT_HOME }}
-        run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
         id: create_revision
+        # revision gets grabbed from last git-svn-id
         run: |
-          ant create-revision
-          josm_revision="$(awk '/Revision/{print $2}' resources/REVISION)"
+          josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 128
+          fetch-depth: 256
       - name: Set revision env variable
         id: create_revision
         # grab josm revision from last git-svn-id
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 128
+          fetch-depth: 256
       - name: Cache
         uses: actions/cache@v2.0.0
         with:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -63,14 +63,15 @@ jobs:
           if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::false"
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::true
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
-          echo "::set-output name=josm_prerelease::$josm_prerelease"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -137,10 +138,29 @@ jobs:
           cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Optimise images
+        if: ${{ runner.os == 'macos' && always() }}
+        run: |
+          brew cask install imageoptim
+          defaults write net.pornel.ImageOptim SvgoEnabled 1
+          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
+          defaults write net.pornel.ImageOptim PngOutEnabled 1
+          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build with Ant
         run: |
-          ${{ env.ANT_HOME }}/bin/ant dist
-      - name: Build with Ant, headless ${{ matrix.headless }}
+          ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+      - name: Upload jar
+        if: ${{ always() && matrix.headless }}
+        id: upload-jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
+          asset_path: dist/josm-custom.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+          asset_content_type: application/java-archive
+      - name: Test with Ant, headless ${{ matrix.headless }}
         if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
@@ -165,7 +185,6 @@ jobs:
           CERT_MACOS_PW: ${{ secrets.CERT_MACOS_PW }}
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
-          $ANT_HOME/bin/ant -DnoErrorProne dist
           ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
@@ -178,14 +197,3 @@ jobs:
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip
-      - name: Upload jar
-        if: ${{ always() }}
-        id: upload-jar
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-          asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -63,14 +63,15 @@ jobs:
           if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
             sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::false"
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
+            echo "::set-output name=josm_prerelease::true
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
-          echo "::set-output name=josm_prerelease::$josm_prerelease"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -137,10 +138,29 @@ jobs:
           cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Optimise images
+        if: ${{ runner.os == 'macos' && always() }}
+        run: |
+          brew cask install imageoptim
+          defaults write net.pornel.ImageOptim SvgoEnabled 1
+          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
+          defaults write net.pornel.ImageOptim PngOutEnabled 1
+          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build with Ant
         run: |
-          ${{ env.ANT_HOME }}/bin/ant dist
-      - name: Build with Ant, headless ${{ matrix.headless }}
+          ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
+      - name: Upload jar
+        if: ${{ always() && matrix.headless }}
+        id: upload-jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
+          asset_path: dist/josm-custom.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+          asset_content_type: application/java-archive
+      - name: Test with Ant, headless ${{ matrix.headless }}
         if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
@@ -158,14 +178,6 @@ jobs:
         with:
           name: Ant reports for JOSM ${{ needs.createrelease.outputs.josm_revision }} on java ${{ matrix.java }} on ${{ matrix.os }} with headless=${{ matrix.headless }}
           path: test/report/*.txt
-      - name: Optimise images
-        if: ${{ runner.os == 'macos' && always() }}
-        run: |
-          brew cask install imageoptim
-          defaults write net.pornel.ImageOptim SvgoEnabled 1
-          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
-          defaults write net.pornel.ImageOptim PngOutEnabled 1
-          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Build and package for macOS
         if: ${{ runner.os == 'macos' && always() }}
         env:
@@ -173,7 +185,6 @@ jobs:
           CERT_MACOS_PW: ${{ secrets.CERT_MACOS_PW }}
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
-          $ANT_HOME/bin/ant -DnoErrorProne dist
           ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
@@ -186,14 +197,3 @@ jobs:
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip
-      - name: Upload jar
-        if: ${{ always() }}
-        id: upload-jar
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-          asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -138,20 +138,19 @@ jobs:
       - name: Upload jar
         # Only run on matrix.headless to avoid double jars. They should be the same jars.
         # uses `gh release upload` to avoid https://github.com/actions/upload-release-asset/issues/69
-        if: ${{ always() && matrix.headless }}
+        if: ${{ always() && matrix.headless == "true" }}
         id: upload-jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # uses: actions/upload-release-asset@v1
-        # with:
-        #   upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-        #   asset_path: dist/josm-custom.jar
-        #   asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-        #   asset_content_type: application/java-archive
-        run: |
-          cp dist/josm-custom.jar JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          gh release upload ${{ needs.createrelease.outputs.josm_release_tag }} JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
+          asset_path: dist/josm-custom.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+          asset_content_type: application/java-archive
+        # run: |
+        #   cp dist/josm-custom.jar JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+        #   gh release upload ${{ needs.createrelease.outputs.josm_release_tag }} JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
       - name: Test with Ant, headless ${{ matrix.headless }}
         if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -23,6 +23,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       josm_revision: ${{ steps.create_revision.outputs.josm_revision }}
       josm_prerelease: ${{ steps.create_revision.outputs.josm_prerelease }}
+      josm_release_tag: ${{ steps.create_revision.outputs.josm_release_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,24 +37,25 @@ jobs:
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::false"
-            echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
+            echo "josm_release_tag=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::true"
-            echo "josm_release=$josm_revision" >> $GITHUB_ENV
+            echo "josm_release_tag=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
+          echo "::set-output name=josm_release_tag::$josm_release_tag"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ env.josm_release }}
-          release_name: JOSM.app release ${{ env.josm_release }}
+          tag_name: ${{ env.josm_release_tag }}
+          release_name: JOSM.app release ${{ env.josm_release_tag }}
           body: |
-            JOSM.app release ${{ env.josm_release }}
+            JOSM.app release ${{ env.josm_release_tag }}
           draft: false
           prerelease: ${{ env.josm_prerelease }}
   build:
@@ -119,7 +121,7 @@ jobs:
           defaults write net.pornel.ImageOptim PngOutEnabled 1
           /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
       - name: Set Is-Local-Build
-        if: ${{ ! env.josm_prerelease }}
+        if: ${{ ! needs.createrelease.outputs.josm_prerelease }}
         run: |
           ant create-revision
           sed -i.bak '/Is-Local-Build/d' resources/REVISION
@@ -133,18 +135,24 @@ jobs:
             ${{ env.ANT_HOME }}/bin/ant dist
           fi
       - name: Upload jar
+        # Only run on matrix.headless to avoid double jars. They should be the same jars.
+        # uses `gh release upload` to avoid https://github.com/actions/upload-release-asset/issues/69
         if: ${{ always() && matrix.headless }}
         id: upload-jar
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-          asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          asset_content_type: application/java-archive
+        # uses: actions/upload-release-asset@v1
+        # with:
+        #   upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
+        #   asset_path: dist/josm-custom.jar
+        #   asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+        #   asset_content_type: application/java-archive
+        run: |
+          cp dist/josm-custom.jar JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+          gh release upload ${{ needs.createrelease.outputs.josm_release_tag }} JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
+
       - name: Test with Ant, headless ${{ matrix.headless }}
-        if: ${{ env.josm_prerelease }}
+        if: ${{ needs.createrelease.outputs.josm_prerelease }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
           if [ "${{ matrix.headless }}" == "true" ]; then

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -166,10 +166,12 @@ jobs:
         if: always()
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
+          path: paths: 'test/report/TEST*.xml'
       - name: Publish Test Report with action-junit-report
+        if: always()
         uses: mikepenz/action-junit-report@v1
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: 'test/report/TEST*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and package for macOS
         if: ${{ runner.os == 'macos' && always() }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,36 +15,52 @@ defaults:
 
 jobs:
   createrelease:
-    name: Create Release
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
-    outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      josm_revision: ${{ steps.create_revision.outputs.josm_revision }}
-      josm_prerelease: ${{ steps.create_revision.outputs.josm_prerelease }}
+    strategy:
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 32
-      - name: Set revision env variable
-        id: create_revision
-        # grab josm revision from last git-svn-id
+      - name: Cache
+        uses: actions/cache@v2.0.0
+        with:
+          path:  |
+            ~/.ivy2/cache/
+            ~/work/josm/josm/tools/
+            ~/build-tools-cache/
+          key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
+      - name: Setup java
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
-          if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
-            sed -i '/Is-Local-Build/d' resources/REVISION
+          mkdir -p ~/build-tools-cache/
+          cd ~/build-tools-cache/
+          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~
+          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+      - name: Print ant version, expecting ${{ env.ANT_HOME }}
+        run: ${{ env.ANT_HOME }}/bin/ant -version
+      - name: Set revision env variable
+        run: |
+          ant create-revision
+          josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
+          if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
+            sed -i .bak '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
-            echo "::set-output name=josm_prerelease::false"
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
-            echo "::set-output name=josm_prerelease::true"
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
-          echo "::set-output name=josm_revision::$josm_revision"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -90,7 +106,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            build-tools-cache/
+            ~/build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -98,49 +114,16 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p build-tools-cache/
-          cd build-tools-cache/
-          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
-            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          fi
-          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          fi
-          cd ..
-          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          mkdir -p ~/build-tools-cache/
+          cd ~/build-tools-cache/
+          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ~
+          tar xzf ~/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp -a ~/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
-      - name: Optimise images
-        if: ${{ runner.os == 'macos' && always() }}
-        run: |
-          brew cask install imageoptim
-          defaults write net.pornel.ImageOptim SvgoEnabled 1
-          defaults write net.pornel.ImageOptim PngCrush2Enabled 1
-          defaults write net.pornel.ImageOptim PngOutEnabled 1
-          /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
-      - name: Build with Ant
-        # Disables errorprone for Java 16
-        # See https://github.com/google/error-prone/issues/1872
-        run: |
-          if [[ "x${{ matrix.java }}x" =~ x1[6-9](-ea)?x ]]; then
-            ${{ env.ANT_HOME }}/bin/ant -DnoErrorProne dist
-          else
-            ${{ env.ANT_HOME }}/bin/ant dist
-          fi
-      - name: Upload jar
-        if: ${{ always() && matrix.headless }}
-        id: upload-jar
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
-          asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
-          asset_content_type: application/java-archive
-      - name: Test with Ant, headless ${{ matrix.headless }}
-        if: ${{ needs.createrelease.outputs.josm_prerelease }}
+      - name: Build with Ant, headless ${{ matrix.headless }}
         run: |
           ANT="${{ env.ANT_HOME }}/bin/ant -DnoJavaFX=true test-unit-hardfail"
           if [ "${{ matrix.headless }}" == "true" ]; then
@@ -164,7 +147,8 @@ jobs:
           CERT_MACOS_PW: ${{ secrets.CERT_MACOS_PW }}
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
-          ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
+          $ANT_HOME/bin/ant -DnoErrorProne dist
+          ./native/macosx/macos-jpackage.sh ${{ env.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
         id: upload-app
@@ -176,3 +160,14 @@ jobs:
           asset_path: app/JOSM.zip
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}.zip
           asset_content_type: application/zip
+      - name: Upload jar
+        if: ${{ always() }}
+        id: upload-jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: dist/josm-custom.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -58,7 +58,7 @@ jobs:
           ant create-revision
           josm_revision=`awk '/Revision/{print $2}' resources/REVISION`
           if [[ "$josm_revision" == `curl --silent https://josm.openstreetmap.de/tested` ]]; then
-            sed -i .bak '/Is-Local-Build/d' resources/REVISION
+            sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
           else

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Upload jar
         # Only run on matrix.headless to avoid double jars. They should be the same jars.
         # uses `gh release upload` to avoid https://github.com/actions/upload-release-asset/issues/69
-        if: ${{ always() && matrix.headless == "true" }}
+        if: ${{ always() && matrix.headless == 'true' }}
         id: upload-jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           josm_revision="$(git log -1 --grep 'git-svn-id: https://josm.openstreetmap.de/svn/trunk@' --pretty=format:%B | tail -1 | sed -n 's%git-svn-id: https://josm.openstreetmap.de/svn/trunk@\([0-9]*\) [-0-9a-f]*%\1%p')"
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
-            sed -i '/Is-Local-Build/d' resources/REVISION
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::false"
             echo "josm_release=$josm_revision-tested" >> $GITHUB_ENV
@@ -119,6 +118,11 @@ jobs:
           defaults write net.pornel.ImageOptim PngCrush2Enabled 1
           defaults write net.pornel.ImageOptim PngOutEnabled 1
           /Applications/ImageOptim.app/Contents/MacOS/ImageOptim resources/images
+      - name: Set Is-Local-Build
+        if: ${{ ! env.josm_prerelease }}
+        run: |
+          ant create-revision
+          sed -i '/Is-Local-Build/d' resources/REVISION
       - name: Build with Ant
         # Disables errorprone for Java 16
         # See https://github.com/google/error-prone/issues/1872

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,7 +31,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/work/josm/josm/build-tools-cache/
+            build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -39,15 +39,17 @@ jobs:
           java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          mkdir -p ~/work/josm/josm/build-tools-cache/
-          cd ~/work/josm/josm/build-tools-cache/
+          mkdir -p build-tools-cache/
+          cd build-tools-cache/
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          fi
+          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
             curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
-          cd ~/work/josm/josm/
-          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ..
+          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Set revision env variable
@@ -108,7 +110,7 @@ jobs:
           path:  |
             ~/.ivy2/cache/
             ~/work/josm/josm/tools/
-            ~/work/josm/josm/build-tools-cache/
+            build-tools-cache/
           key: ${{ runner.os }}-ivy2-${{ hashFiles('ivy.xml') }}
       - name: Setup java
         uses: actions/setup-java@v1.4.3
@@ -116,17 +118,17 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
-          pwd
-          mkdir -p ~/work/josm/josm/build-tools-cache/
-          cd ~/work/josm/josm/build-tools-cache/
+          mkdir -p build-tools-cache/
+          cd build-tools-cache/
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          fi
+          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
             curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
-          cd ~/work/josm/josm/
-          tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
-          cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
-          cp -a ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          cd ..
+          tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
+          cp build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
       - name: Print ant version, expecting ${{ env.ANT_HOME }}
         run: ${{ env.ANT_HOME }}/bin/ant -version
       - name: Build with Ant, headless ${{ matrix.headless }}

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -20,12 +20,12 @@ jobs:
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 32
+          fetch-depth: 64
       - name: Cache
         uses: actions/cache@v2.0.0
         with:
@@ -66,6 +66,7 @@ jobs:
             echo "josm_release=$josm_revision" >> $GITHUB_ENV
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
+          echo "::set-output name=josm_revision::$josm_revision"
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -157,7 +158,7 @@ jobs:
           APPLE_ID_PW: ${{ secrets.APPLE_ID_PW }}
         run: |
           $ANT_HOME/bin/ant -DnoErrorProne dist
-          ./native/macosx/macos-jpackage.sh ${{ env.josm_revision }}
+          ./native/macosx/macos-jpackage.sh ${{ needs.createrelease.outputs.josm_revision }}
       - name: Upload app
         if: ${{ runner.os == 'macos' && always() }}
         id: upload-app
@@ -178,5 +179,5 @@ jobs:
         with:
           upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
-          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
+          asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ needs.createrelease.outputs.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -119,8 +119,10 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
+            curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          fi
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 64
+          fetch-depth: 128
       - name: Set revision env variable
         id: create_revision
         # grab josm revision from last git-svn-id
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 64
+          fetch-depth: 128
       - name: Cache
         uses: actions/cache@v2.0.0
         with:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: '15'
       - name: Install ant ${{ env.ANT_HOME }} and junit ${{ env.junit_platform_version }}
         run: |
           mkdir -p ~/build-tools-cache/

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
-    strategy:
-      fail-fast: false
+    outputs: 
+      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,8 +42,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
@@ -118,8 +118,8 @@ jobs:
           pwd
           mkdir -p ~/work/josm/josm/build-tools-cache/
           cd ~/work/josm/josm/build-tools-cache/
-          wget -N https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
-          wget -N https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          curl -o ${{ env.ANT_HOME }}-bin.tar.gz -z ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
+          curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar -z junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           cd ~/work/josm/josm/
           tar zxf ~/work/josm/josm/build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
           cp ~/work/josm/josm/build-tools-cache/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ${{ env.ANT_HOME }}/lib/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 32
+          fetch-depth: 64
       - name: Set revision env variable
         id: create_revision
         # grab josm revision from last git-svn-id
@@ -81,8 +81,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 32
       - name: Cache
         uses: actions/cache@v2.0.0
         with:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,11 +15,12 @@ defaults:
 
 jobs:
   createrelease:
+    name: Create Release
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,8 +45,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -123,8 +124,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -183,7 +184,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -37,14 +37,15 @@ jobs:
           if [[ "$josm_revision" == "$(curl --silent https://josm.openstreetmap.de/tested)" ]]; then
             echo "josm_prerelease=false" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::false"
-            echo "josm_release_tag=$josm_revision-tested" >> $GITHUB_ENV
+            josm_release_tag=$josm_revision-tested
           else
             echo "josm_prerelease=true" >> $GITHUB_ENV
             echo "::set-output name=josm_prerelease::true"
-            echo "josm_release_tag=$josm_revision" >> $GITHUB_ENV
+            josm_release_tag=$josm_revision
           fi
           echo "josm_revision=$josm_revision" >> $GITHUB_ENV
           echo "::set-output name=josm_revision::$josm_revision"
+          echo "josm_release_tag=$josm_release_tag" >> $GITHUB_ENV
           echo "::set-output name=josm_release_tag::$josm_release_tag"
       - name: Create release
         id: create_release

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -15,11 +15,12 @@ defaults:
 
 jobs:
   createrelease:
+    name: Create Release
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
     outputs: 
-      upload_url: ${{ steps.createrelease.outputs.upload_url }} 
+      upload_url: ${{ steps.create_release.outputs.upload_url }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,8 +45,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -123,8 +124,8 @@ jobs:
           if [ ! -f ${{ env.ANT_HOME }}-bin.tar.gz ]; then
             curl -o ${{ env.ANT_HOME }}-bin.tar.gz https://downloads.apache.org/ant/binaries/${{ env.ANT_HOME }}-bin.tar.gz
           fi
-          if [ ! -f $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
-            curl -o $junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
+          if [ ! -f junit-platform-console-standalone-${{ env.junit_platform_version }}.jar ]; then
+            curl -o junit-platform-console-standalone-${{ env.junit_platform_version }}.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${{ env.junit_platform_version }}/junit-platform-console-standalone-${{ env.junit_platform_version }}.jar
           fi
           cd ..
           tar zxf build-tools-cache/${{ env.ANT_HOME }}-bin.tar.gz
@@ -175,7 +176,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.createrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE job above, referencing its ID to get its outputs object, which include a `upload_url`.
           asset_path: dist/josm-custom.jar
           asset_name: JOSM-${{ runner.os}}-java${{ matrix.java }}-${{ env.josm_revision }}.jar
           asset_content_type: application/java-archive

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,9 +58,8 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
-    - run: |
-      ant dist
+      - run: |
+        ant dist
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,14 +36,16 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-          fetch-depth: 32
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
@@ -56,9 +58,10 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-    - name: Build with Ant
-      run: |
-        ant 
-        
+
+    - run: |
+    #   make bootstrap
+        ant dist
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,8 +47,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-          fetch-depth: 32
+          fetch-depth: 128
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+          fetch-depth: 32
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-          fetch-depth: 128
+          fetch-depth: 256
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,8 +60,7 @@ jobs:
     #    uses a compiled language
 
     - run: |
-    #   make bootstrap
-        ant dist
+      ant dist
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,10 +42,6 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
@@ -58,8 +54,9 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-      - run: |
-        ant dist
-
+    - name: Build with Ant
+      run: |
+        ant 
+        
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -55,11 +55,10 @@ else
 fi
 
 echo "Building and signin app"
-    jpackage "$JPACKAGEOPTIONS" -n "JOSM" --input dist --main-jar josm-custom.jar \
+    jpackage $JPACKAGEOPTIONS -n "JOSM" --input dist --main-jar josm-custom.jar \
     --main-class org.openstreetmap.josm.gui.MainApplication \
     --icon ./native/macosx/JOSM.icns --type app-image --dest app \
     --java-options "-Xmx8192m" \
-     --java-options "-Dapple.awt.application.appearance=system" \
     --app-version "$1" \
     --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
     --vendor "https://josm.openstreetmap.de" \

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -55,12 +55,12 @@ else
 fi
 
 echo "Building and signin app"
-    jpackage $JPACKAGEOPTIONS -n "JOSM" --input dist --main-jar josm-custom.jar \
+    jpackage "$JPACKAGEOPTIONS" -n "JOSM" --input dist --main-jar josm-custom.jar \
     --main-class org.openstreetmap.josm.gui.MainApplication \
     --icon ./native/macosx/JOSM.icns --type app-image --dest app \
     --java-options "-Xmx8192m" \
      --java-options "-Dapple.awt.application.appearance=system" \
-    --app-version $1 \
+    --app-version "$1" \
     --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
     --vendor "https://josm.openstreetmap.de" \
     --mac-sign \
@@ -79,8 +79,9 @@ echo "Building and signin app"
 
 echo "Building done."
 
-echo "Preparing for notarization"
-ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip
+if $SIGNAPP; then
+    echo "Preparing for notarization"
+    ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip
 
     echo "Uploading to Apple"
     xcrun altool --notarize-app -f app/JOSM.zip -p "$APPLE_ID_PW" -u "$APPLE_ID" --primary-bundle-id de.openstreetmap.josm

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -64,8 +64,7 @@ echo "Building and signin app"
     --mac-sign \
     --mac-package-identifier de.openstreetmap.josm \
     --mac-package-signing-prefix de.openstreetmap.josm \
-    --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
-    --mac-signing-keychain $KEYCHAIN \
+    --mac-signing-keychain $KEYCHAINPATH \
     --file-associations native/macosx/bz2.properties \
     --file-associations native/macosx/geojson.properties \
     --file-associations native/macosx/gpx.properties \

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -85,7 +85,7 @@ echo "Signing App Bundle…"
 #     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
 #     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
 
-# codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app
+codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app/Contents/app/josm-custom.jar
 
 # codesign -vvv app/JOSM.app
 

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -58,7 +58,9 @@ echo "Building and signin app"
     jpackage $JPACKAGEOPTIONS -n "JOSM" --input dist --main-jar josm-custom.jar \
     --main-class org.openstreetmap.josm.gui.MainApplication \
     --icon ./native/macosx/JOSM.icns --type app-image --dest app \
-    --java-options "-Xmx8192m" --app-version $1 \
+    --java-options "-Xmx8192m" \
+     --java-options "-Dapple.awt.application.appearance=system" \
+    --app-version $1 \
     --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
     --vendor "https://josm.openstreetmap.de" \
     --mac-sign \
@@ -76,18 +78,6 @@ echo "Building and signin app"
     --add-modules java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.sql,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.jfr,jdk.jsobject,jdk.unsupported,jdk.unsupported.desktop,jdk.xml.dom
 
 echo "Building done."
-
-echo "Signing App Bundle…"
-
-# codesign -vvv --timestamp --options runtime --deep --force --sign "$SIGNING_KEY_NAME" \
-#     app/JOSM.app/Contents/MacOS/JOSM \
-#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.jar \
-#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
-#     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
-
-codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app/Contents/app/josm-custom.jar
-
-# codesign -vvv app/JOSM.app
 
 echo "Preparing for notarization"
 ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -58,15 +58,13 @@ echo "Building and signin app"
     jpackage $JPACKAGEOPTIONS -n "JOSM" --input dist --main-jar josm-custom.jar \
     --main-class org.openstreetmap.josm.gui.MainApplication \
     --icon ./native/macosx/JOSM.icns --type app-image --dest app \
-    --java-options "-Xmx8192m" \
-     --java-options "-Dapple.awt.application.appearance=system" \
-    --app-version $1 \
+    --java-options "-Xmx8192m" --app-version $1 \
     --copyright "JOSM, and all its integral parts, are released under the GNU General Public License v2 or later" \
     --vendor "https://josm.openstreetmap.de" \
     --mac-sign \
     --mac-package-identifier de.openstreetmap.josm \
     --mac-package-signing-prefix de.openstreetmap.josm \
-    --mac-signing-keychain $KEYCHAINPATH \
+    --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
     --file-associations native/macosx/bz2.properties \
     --file-associations native/macosx/geojson.properties \
     --file-associations native/macosx/gpx.properties \
@@ -78,6 +76,18 @@ echo "Building and signin app"
     --add-modules java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.sql,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.jfr,jdk.jsobject,jdk.unsupported,jdk.unsupported.desktop,jdk.xml.dom
 
 echo "Building done."
+
+echo "Signing App Bundle…"
+
+# codesign -vvv --timestamp --options runtime --deep --force --sign "$SIGNING_KEY_NAME" \
+#     app/JOSM.app/Contents/MacOS/JOSM \
+#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.jar \
+#     app/JOSM.app/Contents/runtime/Contents/Home/lib/*.dylib \
+#     app/JOSM.app/Contents/runtime/Contents/MacOS/libjli.dylib
+
+# codesign -vvv --timestamp --entitlements native/macosx/josm.entitlements --options runtime --force --sign "$SIGNING_KEY_NAME" app/JOSM.app
+
+# codesign -vvv app/JOSM.app
 
 echo "Preparing for notarization"
 ditto -c -k --zlibCompressionLevel 9 --keepParent app/JOSM.app app/JOSM.zip

--- a/native/macosx/macos-jpackage.sh
+++ b/native/macosx/macos-jpackage.sh
@@ -65,6 +65,7 @@ echo "Building and signin app"
     --mac-package-identifier de.openstreetmap.josm \
     --mac-package-signing-prefix de.openstreetmap.josm \
     --mac-signing-key-user-name "$SIGNING_KEY_NAME" \
+    --mac-signing-keychain $KEYCHAIN \
     --file-associations native/macosx/bz2.properties \
     --file-associations native/macosx/geojson.properties \
     --file-associations native/macosx/gpx.properties \

--- a/src/org/openstreetmap/josm/gui/MainApplication.java
+++ b/src/org/openstreetmap/josm/gui/MainApplication.java
@@ -1043,10 +1043,13 @@ public class MainApplication {
                 Logging.log(Logging.LEVEL_ERROR, null, e);
             }
         } 
-        // Workaround for https://josm.openstreetmap.de/ticket/20075
+        // Workaround for JDK-8251377: JTabPanel active tab is unreadable in Big Sur, see #20075
+        // os.version will return 10.16, or 11.0 depending on environment variable
+        // https://twitter.com/BriceDutheil/status/1330926649269956612
         else {
             final String laf = UIManager.getLookAndFeel().getID();
-            if(PlatformManager.isPlatformOsx() && (laf.contains("Mac") || laf.contains("Aqua"))){
+            final String macOSVersion = getSystemProperty("os.version");
+            if(PlatformManager.isPlatformOsx() && (laf.contains("Mac") || laf.contains("Aqua")) && (macOSVersion.startsWith("10.16") || macOSVersion.startsWith("11"))){
                 UIManager.put("TabbedPane.foreground", Color.BLACK);
             }
         }

--- a/src/org/openstreetmap/josm/gui/MainApplication.java
+++ b/src/org/openstreetmap/josm/gui/MainApplication.java
@@ -6,6 +6,7 @@ import static org.openstreetmap.josm.tools.I18n.trn;
 import static org.openstreetmap.josm.tools.Utils.getSystemProperty;
 
 import java.awt.AWTError;
+import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -1040,6 +1041,13 @@ public class MainApplication {
                 Logging.error(e);
             } catch (ExceptionInInitializerError e) {
                 Logging.log(Logging.LEVEL_ERROR, null, e);
+            }
+        } 
+        // Workaround for https://josm.openstreetmap.de/ticket/20075
+        else {
+            final String laf = UIManager.getLookAndFeel().getID();
+            if(PlatformManager.isPlatformOsx() && (laf.contains("Mac") || laf.contains("Aqua"))){
+                UIManager.put("TabbedPane.foreground", Color.BLACK);
             }
         }
     }

--- a/src/org/openstreetmap/josm/tools/PlatformHookOsx.java
+++ b/src/org/openstreetmap/josm/tools/PlatformHookOsx.java
@@ -25,6 +25,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.openstreetmap.josm.data.Preferences;
@@ -82,14 +83,15 @@ public class PlatformHookOsx implements PlatformHook, InvocationHandler {
                 setHandlers(Desktop.class, quitHandler, aboutHandler, openFilesHandler, preferencesHandler, proxy, Desktop.getDesktop());
             }
             // setup the dock icon. It is automatically set with application bundle and Web start but we need
-            // to do it manually if run with `java -jar``
-            try {
-                eawtApplication.getDeclaredMethod("setDockIconImage", Image.class).invoke(appli, ImageProvider.get(Config.getUrls().getJOSMWebsite()+"/logo-macos.png").getImage());
-            } catch (JosmRuntimeException e) {
-                // fall back to default logo
-                eawtApplication.getDeclaredMethod("setDockIconImage", Image.class).invoke(appli, ImageProvider.get("logo").getImage());
-            }
-            
+            // to do it manually if run with `java -jar``. Fall back to default icon
+            eawtApplication.getDeclaredMethod("setDockIconImage", Image.class).invoke(
+                appli, 
+                Optional.ofNullable(
+                    new ImageProvider(Config.getUrls().getJOSMWebsite()+"/logo-macos.png").setOptional(true).get()
+                ).orElse(
+                    ImageProvider.get("logo")).getImage()
+            );
+        
             // enable full screen
             enableOSXFullscreen(MainApplication.getMainFrame());
         } catch (ReflectiveOperationException | SecurityException | IllegalArgumentException ex) {

--- a/src/org/openstreetmap/josm/tools/PlatformHookOsx.java
+++ b/src/org/openstreetmap/josm/tools/PlatformHookOsx.java
@@ -83,12 +83,12 @@ public class PlatformHookOsx implements PlatformHook, InvocationHandler {
                 setHandlers(Desktop.class, quitHandler, aboutHandler, openFilesHandler, preferencesHandler, proxy, Desktop.getDesktop());
             }
             // setup the dock icon. It is automatically set with application bundle and Web start but we need
-            // to do it manually if run with `java -jar``. Fall back to default icon
+            // to do it manually if run with `java -jar``. 
             eawtApplication.getDeclaredMethod("setDockIconImage", Image.class).invoke(
                 appli, 
                 Optional.ofNullable(
                     new ImageProvider(Config.getUrls().getJOSMWebsite()+"/logo-macos.png").setOptional(true).get()
-                ).orElse(
+                ).orElse( // Fall back to default icon
                     ImageProvider.get("logo")).getImage()
             );
         


### PR DESCRIPTION
- Fix macOS dock icon resetting to default one. Fetches macOS icon over https (in case we're a jar), saves 77K in the jar. (https://josm.openstreetmap.de/ticket/20133)
- Fix unreadable macOS tabs (https://josm.openstreetmap.de/ticket/20075)
- Fix macOS tested build doesn't know it's tested (https://josm.openstreetmap.de/ticket/20202)
- Better documentation of the macOS build process in the scripts, and better shell syntax
- Allow building of a JOSM.app without having signing keys installed - useful for local builds.

Also:

- Activate CodeQL code quality checks (not macOS-related)