### PR TITLE
Fix parsing of empty parenthesis pairs in search expressions

### DIFF
--- a/src/org/openstreetmap/josm/data/osm/search/SearchCompiler.java
+++ b/src/org/openstreetmap/josm/data/osm/search/SearchCompiler.java
@@ -2128,7 +2128,7 @@ public class SearchCompiler {
             Match expression = parseExpression();
             if (!tokenizer.readIfEqual(Token.RIGHT_PARENT))
                 throw new SearchParseError(Token.RIGHT_PARENT, tokenizer.nextToken());
-            return expression;
+            return expression != null ? expression : Always.INSTANCE;
         } else if (tokenizer.readIfEqual(Token.NOT)) {
             return new Not(parseFactor(tr("Missing operator for NOT")));
         } else if (tokenizer.readIfEqual(Token.KEY)) {

--- a/test/unit/org/openstreetmap/josm/data/osm/search/SearchCompilerTest.java
+++ b/test/unit/org/openstreetmap/josm/data/osm/search/SearchCompilerTest.java
@@ -840,4 +840,14 @@ class SearchCompilerTest {
     void testNonRegression21300(final String searchString) {
         assertThrows(SearchParseError.class, () -> SearchCompiler.compile(searchString));
     }
+
+    /**
+     * Non-regression test for JOSM #21463
+     */
+    @Test
+    void testNonRegression21463() throws SearchParseError {
+        final SearchCompiler.Match c = SearchCompiler.compile("foo () () () bar");
+        assertTrue(c.match(OsmUtils.createPrimitive("node foo=bar")));
+        assertFalse(c.match(OsmUtils.createPrimitive("node name=bar")));
+    }
 }


### PR DESCRIPTION
Empty parenthesis pairs at the top level of a search expression erroneously led to early termination of expression parsing. With this patch, they should be correctly parsed as matching everything.

The JOSM search expression parser repeatedly calls `parseFactor()` until it returns null (which usually means the end of the string has been reached). The problem is that `parseFactor()` also returns null when it encounters an empty parenthesis pair `()` and therefore terminates expression parsing early.
With e.g. `parent ()`, the `()` subexpression is also parsed with `parseExpression()` and `parseFactor()`, which also returns null in this case, but that result is then used to construct the `Parent()` match, which treats `null` as matching everything
i.e. `()` in sub-expressions gets treated as matching everything while it leads to an error when it occurs in the top level