### PR TITLE
Add surface=laterite to the surface preset

### DIFF
--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -6,7 +6,7 @@
 
     <!-- Item chunks -->
     <chunk id="surface">
-        <combo key="surface" text="Surface" values="paved,unpaved,asphalt,concrete,concrete:plates,concrete:lanes,paving_stones,sett,cobblestone,unhewn_cobblestone,grass_paver,compacted,fine_gravel,gravel,pebblestone,ground,mud,rock,sand,grass,wood,metal,stone,woodchips" />
+        <combo key="surface" text="Surface" values="paved,unpaved,asphalt,concrete,concrete:plates,concrete:lanes,paving_stones,sett,cobblestone,unhewn_cobblestone,grass_paver,compacted,fine_gravel,gravel,pebblestone,ground,mud,rock,sand,grass,wood,metal,stone,woodchips,laterite" />
     </chunk>
     <chunk id="surface_smoothness">
         <reference ref="surface" />


### PR DESCRIPTION
Fixes josm.openstreetmap.de/ticket/24792.

`surface=laterite` was approved via OSM's proposal process ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite), 29-0-0) and is documented at [Tag:surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite). The shared `surface` combo in `defaultpresets.xml` doesn't have an entry for it yet. This adds `laterite` to that values list, one value appended to the existing list, no other changes.

I know this mirror doesn't see much merge activity since JOSM development is primarily SVN/Trac-based. I'll follow up with the same patch on the Trac ticket directly in case that's the more useful channel, happy to close this PR if so, just didn't want to assume.